### PR TITLE
Refactor probe implementations into dedicated files

### DIFF
--- a/internal/probes/dns.go
+++ b/internal/probes/dns.go
@@ -1,0 +1,51 @@
+package probes
+
+import (
+	"context"
+	"net"
+	"time"
+)
+
+type DNSResult struct {
+	AvgMs   float64  `json:"avg_ms"`
+	Answers []string `json:"answers"`
+}
+
+func DNSLookupTimed(host string, resolvers []string) (DNSResult, error) {
+	if len(resolvers) == 0 {
+		resolvers = []string{""}
+	}
+
+	var total float64
+	var count int
+	answers := make([]string, 0)
+
+	for _, resolver := range resolvers {
+		r := net.Resolver{}
+		if resolver != "" {
+			dialer := func(ctx context.Context, network, address string) (net.Conn, error) {
+				d := &net.Dialer{Timeout: 2 * time.Second}
+				return d.DialContext(ctx, network, net.JoinHostPort(resolver, "53"))
+			}
+			r = net.Resolver{PreferGo: true, Dial: dialer}
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		start := time.Now()
+		ips, err := r.LookupHost(ctx, host)
+		elapsed := time.Since(start).Seconds() * 1000
+		cancel()
+		if err == nil {
+			total += elapsed
+			count++
+			answers = append(answers, ips...)
+		}
+	}
+
+	var avg float64
+	if count > 0 {
+		avg = total / float64(count)
+	}
+
+	return DNSResult{AvgMs: avg, Answers: answers}, nil
+}

--- a/internal/probes/mtu.go
+++ b/internal/probes/mtu.go
@@ -1,0 +1,42 @@
+package probes
+
+import (
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+type MTUResult struct {
+	PathMTU int    `json:"path_mtu"`
+	Raw     string `json:"raw"`
+}
+
+func MTUCheck(target string) (MTUResult, error) {
+	if runtime.GOOS == "windows" {
+		sizes := []int{1472, 1460, 1452, 1400, 1300, 1200}
+		for _, sz := range sizes {
+			out, _ := exec.Command("ping", "-f", "-l", strconv.Itoa(sz), "-n", "2", target).CombinedOutput()
+			txt := strings.ToLower(string(out))
+			if !(strings.Contains(txt, "needs to be fragmented") || strings.Contains(txt, "packet needs to be fragmented")) {
+				return MTUResult{PathMTU: sz + 28, Raw: string(out)}, nil
+			}
+		}
+		return MTUResult{PathMTU: 0, Raw: "DF tests failed"}, nil
+	}
+
+	if runtime.GOOS == "linux" {
+		sizes := []int{1472, 1460, 1452, 1400, 1300, 1200}
+		for _, sz := range sizes {
+			out, _ := exec.Command("ping", "-M", "do", "-s", strconv.Itoa(sz), "-c", "2", target).CombinedOutput()
+			txt := strings.ToLower(string(out))
+			if !(strings.Contains(txt, "message too long") || strings.Contains(txt, "frag needed")) {
+				return MTUResult{PathMTU: sz + 28, Raw: string(out)}, nil
+			}
+		}
+		return MTUResult{PathMTU: 0, Raw: "DF tests failed"}, nil
+	}
+
+	out, _ := exec.Command("ping", "-c", "2", target).CombinedOutput()
+	return MTUResult{PathMTU: 0, Raw: string(out)}, nil
+}

--- a/internal/probes/trace.go
+++ b/internal/probes/trace.go
@@ -7,39 +7,36 @@ import (
 	"strings"
 )
 
-type MTUResult struct {
-	PathMTU int    `json:"path_mtu"`
-	Raw     string `json:"raw"`
+type TraceResult struct {
+	Raw string `json:"raw"`
 }
 
-// Pragmatic: try common payload sizes with DF where supported.
-// On macOS, DF flags may not be available; we return PathMTU=0 with raw output.
-func MTUCheck(target string) (MTUResult, error) {
-	if runtime.GOOS == "windows" {
-		// Windows ping uses -f (DF) and -l (size). Try descending sizes.
-		sizes := []int{1472, 1460, 1452, 1400, 1300, 1200}
-		for _, sz := range sizes {
-			out, _ := exec.Command("ping", "-f", "-l", strconv.Itoa(sz), "-n", "2", target).CombinedOutput()
-			txt := strings.ToLower(string(out))
-			if !(strings.Contains(txt, "needs to be fragmented") || strings.Contains(txt, "packet needs to be fragmented")) {
-				return MTUResult{PathMTU: sz + 28, Raw: string(out)}, nil
-			}
-		}
-		return MTUResult{PathMTU: 0, Raw: "DF tests failed"}, nil
+func Trace(target string, maxHops int) (TraceResult, error) {
+	if maxHops <= 0 {
+		maxHops = 30
 	}
-	// Linux (and sometimes BSD): -M do sets DF; -s size
-	if runtime.GOOS == "linux" {
-		sizes := []int{1472, 1460, 1452, 1400, 1300, 1200}
-		for _, sz := range sizes {
-			out, _ := exec.Command("ping", "-M", "do", "-s", strconv.Itoa(sz), "-c", "2", target).CombinedOutput()
-			txt := strings.ToLower(string(out))
-			if !(strings.Contains(txt, "message too long") || strings.Contains(txt, "frag needed")) {
-				return MTUResult{PathMTU: sz + 28, Raw: string(out)}, nil
-			}
+
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "windows":
+		cmd = exec.Command("tracert", "-d", "-h", strconv.Itoa(maxHops), target)
+	default:
+		if _, err := exec.LookPath("traceroute"); err == nil {
+			cmd = exec.Command("traceroute", "-n", "-m", strconv.Itoa(maxHops), target)
+		} else {
+			// Fallback to tracepath if traceroute is unavailable.
+			cmd = exec.Command("tracepath", "-n", target)
 		}
-		return MTUResult{PathMTU: 0, Raw: "DF tests failed"}, nil
 	}
-	// macOS or others: fall back with no DF support (report 0)
-	out, _ := exec.Command("ping", "-c", "2", target).CombinedOutput()
-	return MTUResult{PathMTU: 0, Raw: string(out)}, nil
+
+	out, err := cmd.CombinedOutput()
+	result := TraceResult{Raw: string(out)}
+	if err != nil {
+		return result, err
+	}
+	// tracepath default limit may differ; annotate hops if necessary.
+	if runtime.GOOS != "windows" && strings.Contains(cmd.Path, "tracepath") {
+		result.Raw = strings.TrimSpace(result.Raw)
+	}
+	return result, nil
 }


### PR DESCRIPTION
## Summary
- reorganize the probe package so each responsibility lives in its own file
- rebuild the ping, DNS, trace, and MTU helpers without duplicate types
- keep the existing netinfo helpers while trimming imports and ensuring shared types are exported once

## Testing
- GOSUMDB=off GOPROXY=off go build ./internal/probes
- GOSUMDB=off GOPROXY=off go run ./cmd/vne-agent --target 8.8.8.8 --out r.html --skip-python *(fails: missing assets/report_template.html)*
- GOSUMDB=off GOPROXY=off go run ./cmd/vne-agent *(fails: missing assets/report_template.html)*

------
https://chatgpt.com/codex/tasks/task_e_68e1102fc188832ca8deb4fc44e74343