### PR TITLE
Add Go CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+      - name: Go build
+        run: go build ./...
+      - name: Go vet
+        run: go vet ./...


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds and vets the Go project on Ubuntu, macOS, and Windows using Go 1.22

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e1154bdf9c832caaa9d4d45cb17c92