### PR TITLE
Add embedded fallback for report template

### DIFF
--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -6,8 +6,13 @@ import (
 	"os"
 	"time"
 
+	_ "embed"
+
 	"github.com/cneate93/vne/internal/probes"
 )
+
+//go:embed report_template.html
+var defaultReportTemplate string
 
 type Finding struct {
 	Severity string `json:"severity"`
@@ -36,7 +41,7 @@ type Results struct {
 func RenderHTML(r Results, tmplPath, outPath string) error {
 	tplBytes, err := os.ReadFile(tmplPath)
 	if err != nil {
-		return err
+		tplBytes = []byte(defaultReportTemplate)
 	}
 	tpl, err := template.New("rep").Parse(string(tplBytes))
 	if err != nil {

--- a/internal/report/report_template.html
+++ b/internal/report/report_template.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8"/>
+  <title>VNE Report</title>
+  <style>
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; margin: 2rem; }
+    h1 { margin-bottom: 0; }
+    .sub { color:#666; margin-top:0.2rem; }
+    pre { background:#f6f8fa; padding:1rem; overflow:auto; }
+    table { border-collapse: collapse; width:100%; margin:1rem 0; }
+    th, td { border:1px solid #ddd; padding:8px; font-size:14px; }
+    th { background:#fafafa; text-align:left; }
+    .sev-high { color:#b00020; font-weight:bold; }
+    .sev-medium { color:#b08900; font-weight:bold; }
+    .sev-info { color:#0066b0; font-weight:bold; }
+    code { background:#f1f1f1; padding:0.1rem 0.3rem; border-radius:4px; }
+  </style>
+</head>
+<body>
+  <h1>Virtual Network Engineer — Report</h1>
+  <div class="sub">{{ .When }}</div>
+
+  {{ if .UserNote }}
+  <h2>Problem Description</h2>
+  <p>{{ .UserNote }}</p>
+  {{ end }}
+
+  <h2>Summary Findings</h2>
+  {{ if .Findings }}
+    <ul>
+      {{ range .Findings }}
+        <li><span class="sev-{{ .Severity }}">{{ .Severity }}</span> — {{ .Message }}</li>
+      {{ end }}
+    </ul>
+  {{ else }}
+    <p>No major issues detected by the MVP checks.</p>
+  {{ end }}
+
+  <h2>Local Network Info</h2>
+  <table>
+    <tr><th>Hostname</th><td>{{ .NetInfo.HostName }}</td></tr>
+    <tr><th>Default Gateway</th><td>{{ if .HasGateway }}{{ .GatewayUsed }}{{ else }}(none detected){{ end }}</td></tr>
+    <tr><th>DNS Servers</th><td>{{ range $i, $v := .NetInfo.DNSServers }}{{ if $i }}, {{ end }}{{ $v }}{{ end }}</td></tr>
+  </table>
+
+  <h3>Interfaces</h3>
+  <table>
+    <tr><th>Name</th><th>Up</th><th>MAC</th><th>IPs</th></tr>
+    {{ range .NetInfo.Interfaces }}
+      <tr>
+        <td>{{ .Name }}</td>
+        <td>{{ .Up }}</td>
+        <td>{{ .Mac }}</td>
+        <td>{{ range $i, $v := .IPs }}{{ if $i }}, {{ end }}{{ $v }}{{ end }}</td>
+      </tr>
+    {{ end }}
+  </table>
+
+  <h2>Connectivity Checks</h2>
+  <table>
+    <tr><th>Check</th><th>Target</th><th>Avg (ms)</th><th>Loss</th></tr>
+    <tr><td>Gateway Ping</td><td>{{ if .HasGateway }}{{ .GatewayUsed }}{{ else }}(n/a){{ end }}</td><td>{{ printf "%.1f" .GwPing.AvgMs }}</td><td>{{ .GwLossPct }}</td></tr>
+    <tr><td>WAN Ping</td><td>{{ .TargetHost }}</td><td>{{ printf "%.1f" .WanPing.AvgMs }}</td><td>{{ .WanLossPct }}</td></tr>
+  </table>
+
+  <h2>DNS</h2>
+  <table>
+    <tr><th>Path</th><th>Avg (ms)</th><th>Answers</th></tr>
+    <tr><td>System resolvers</td><td>{{ printf "%.0f" .DNSLocal.AvgMs }}</td><td>{{ range $i, $v := .DNSLocal.Answers }}{{ if $i }}, {{ end }}{{ $v }}{{ end }}</td></tr>
+    <tr><td>1.1.1.1</td><td>{{ printf "%.0f" .DNSCF.AvgMs }}</td><td>{{ range $i, $v := .DNSCF.Answers }}{{ if $i }}, {{ end }}{{ $v }}{{ end }}</td></tr>
+  </table>
+
+  <h2>Path MTU</h2>
+  <table>
+    <tr><th>Path MTU (bytes)</th><td>{{ .MTU.PathMTU }}</td></tr>
+  </table>
+
+  <h2>Traceroute</h2>
+  <pre>{{ .Trace.Raw }}</pre>
+
+  {{ if .FortiRaw }}
+  <h2>FortiGate Pack (Raw)</h2>
+  <pre>{{ printf "%+v" .FortiRaw }}</pre>
+  {{ end }}
+
+  <h2>Raw Ping Outputs</h2>
+  <details>
+    <summary>Gateway ping raw</summary>
+    <pre>{{ .GwPing.Raw }}</pre>
+  </details>
+  <details>
+    <summary>WAN ping raw</summary>
+    <pre>{{ .WanPing.Raw }}</pre>
+  </details>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- embed the report HTML template directly in the report package
- fall back to the embedded copy if loading the on-disk template fails

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e1150ee7b4832c9e1124ab20e8ecc6