### PR TITLE
Add template helpers for report unit formatting

### DIFF
--- a/assets/report_template.html
+++ b/assets/report_template.html
@@ -59,16 +59,16 @@
 
   <h2>Connectivity Checks</h2>
   <table>
-    <tr><th>Check</th><th>Target</th><th>Avg (ms)</th><th>Loss</th></tr>
-    <tr><td>Gateway Ping</td><td>{{ if .HasGateway }}{{ .GatewayUsed }}{{ else }}(n/a){{ end }}</td><td>{{ printf "%.1f" .GwPing.AvgMs }}</td><td>{{ .GwLossPct }}</td></tr>
-    <tr><td>WAN Ping</td><td>{{ .TargetHost }}</td><td>{{ printf "%.1f" .WanPing.AvgMs }}</td><td>{{ .WanLossPct }}</td></tr>
+    <tr><th>Check</th><th>Target</th><th>Avg</th><th>Loss</th></tr>
+    <tr><td>Gateway Ping</td><td>{{ if .HasGateway }}{{ .GatewayUsed }}{{ else }}(n/a){{ end }}</td><td>{{ ms1 .GwPing.AvgMs }}</td><td>{{ pct .GwPing.Loss }}</td></tr>
+    <tr><td>WAN Ping</td><td>{{ .TargetHost }}</td><td>{{ ms1 .WanPing.AvgMs }}</td><td>{{ pct .WanPing.Loss }}</td></tr>
   </table>
 
   <h2>DNS</h2>
   <table>
-    <tr><th>Path</th><th>Avg (ms)</th><th>Answers</th></tr>
-    <tr><td>System resolvers</td><td>{{ printf "%.0f" .DNSLocal.AvgMs }}</td><td>{{ range $i, $v := .DNSLocal.Answers }}{{ if $i }}, {{ end }}{{ $v }}{{ end }}</td></tr>
-    <tr><td>1.1.1.1</td><td>{{ printf "%.0f" .DNSCF.AvgMs }}</td><td>{{ range $i, $v := .DNSCF.Answers }}{{ if $i }}, {{ end }}{{ $v }}{{ end }}</td></tr>
+    <tr><th>Path</th><th>Avg</th><th>Answers</th></tr>
+    <tr><td>System resolvers</td><td>{{ ms1 .DNSLocal.AvgMs }}</td><td>{{ range $i, $v := .DNSLocal.Answers }}{{ if $i }}, {{ end }}{{ $v }}{{ end }}</td></tr>
+    <tr><td>1.1.1.1</td><td>{{ ms1 .DNSCF.AvgMs }}</td><td>{{ range $i, $v := .DNSCF.Answers }}{{ if $i }}, {{ end }}{{ $v }}{{ end }}</td></tr>
   </table>
 
   <h2>Path MTU</h2>

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -2,6 +2,7 @@ package report
 
 import (
 	"bytes"
+	"fmt"
 	"html/template"
 	"os"
 	"time"
@@ -41,7 +42,15 @@ func RenderHTML(r Results, tmplPath, outPath string) error {
 	if err != nil {
 		tplBytes = []byte(defaultReportTemplate)
 	}
-	tpl, err := template.New("rep").Parse(string(tplBytes))
+	funcMap := template.FuncMap{
+		"pct": func(v float64) string {
+			return fmt.Sprintf("%.0f%%", v*100)
+		},
+		"ms1": func(v float64) string {
+			return fmt.Sprintf("%.1f ms", v)
+		},
+	}
+	tpl, err := template.New("rep").Funcs(funcMap).Parse(string(tplBytes))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
- add pct and ms1 helpers to the report renderer and wire them into the template
- show latency with units and format loss percentages directly from numeric probe results
- align DNS latency display with the new helper formatting

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e125214a74832c9257c598a31d445c