### PR TITLE
Add VPN-aware MTU hinting to findings

### DIFF
--- a/cmd/vne-agent/main.go
+++ b/cmd/vne-agent/main.go
@@ -227,6 +227,17 @@ func main() {
 			Message:  fmt.Sprintf("Path MTU appears to be %d. If VPN/tunnel is in path, lower MTU or enable TCP MSS clamping.", mtu.PathMTU),
 		})
 	}
+	vpnAdapters := netInfo.VPNAdapterNames()
+	if len(vpnAdapters) > 0 && (mtu.PathMTU == 0 || mtu.PathMTU < 1500) {
+		mtuPhrase := "Path MTU probe was inconclusive"
+		if mtu.PathMTU > 0 {
+			mtuPhrase = fmt.Sprintf("Path MTU reported as %d", mtu.PathMTU)
+		}
+		findings = append(findings, report.Finding{
+			Severity: "info",
+			Message:  fmt.Sprintf("%s with active VPN/tunnel adapter (%s). Set tunnel MTU to 1420–1412 and enable TCP MSS clamping to avoid fragmentation.", mtuPhrase, strings.Join(vpnAdapters, ", ")),
+		})
+	}
 
 	// 9) Assemble report (pre-format loss % strings to keep template simple)
 	res := report.Results{

--- a/internal/probes/netinfo.go
+++ b/internal/probes/netinfo.go
@@ -22,6 +22,29 @@ type IF struct {
 	Up   bool     `json:"up"`
 }
 
+// VPNAdapterNames returns the set of active interfaces that appear to be
+// VPN/tunnel adapters. This is based on common interface name patterns for
+// popular VPN clients and tunnelling drivers (WireGuard, OpenVPN, etc.).
+func (ni NetInfo) VPNAdapterNames() []string {
+	var matches []string
+	for _, iface := range ni.Interfaces {
+		if !iface.Up {
+			continue
+		}
+		nameLower := strings.ToLower(iface.Name)
+		switch {
+		case strings.Contains(nameLower, "nord"),
+			strings.Contains(nameLower, "openvpn"),
+			strings.Contains(nameLower, "wireguard"),
+			strings.HasPrefix(nameLower, "tun"),
+			strings.HasPrefix(nameLower, "tap"),
+			strings.HasPrefix(nameLower, "wg"):
+			matches = append(matches, iface.Name)
+		}
+	}
+	return matches
+}
+
 func GetBasics() (NetInfo, error) {
 	var ni NetInfo
 	hn, _ := execLook("hostname")


### PR DESCRIPTION
## Summary
- add VPN/tunnel interface detection to the network information probe
- surface an MTU/MSS optimization finding when a VPN adapter is active and the path MTU is limited or unknown

## Testing
- go test ./... *(hangs; interrupted after waiting)*

------
https://chatgpt.com/codex/tasks/task_e_68e12f583bf4832caaa759f331e94d69