### PR TITLE
Add minimal Go CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,23 +1,31 @@
-name: CI
+name: Minimal CI
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
+
+permissions:
+  contents: read
 
 jobs:
   build:
+    name: build and vet (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Go
-        uses: actions/setup-go@v5
+      - uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: '1.22.x'
       - name: Go build
         run: go build ./...
       - name: Go vet


### PR DESCRIPTION
## Summary
- add a minimal CI workflow that runs `go build` and `go vet` on Linux, macOS, and Windows
- ensure the workflow uses Go 1.22 via `actions/setup-go@v5`

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e132b4a70c832c9aa2e3772ee54cdb