### PR TITLE
Rename evidence bundle JSON artifact

### DIFF
--- a/internal/report/zip.go
+++ b/internal/report/zip.go
@@ -26,6 +26,7 @@ func WriteBundle(outZip string, results Results, raws map[string][]byte) (err er
 	if err != nil {
 		return fmt.Errorf("marshal results: %w", err)
 	}
+	jsonBytes = append(jsonBytes, '\n')
 
 	file, err := os.Create(outZip)
 	if err != nil {
@@ -49,7 +50,7 @@ func WriteBundle(outZip string, results Results, raws map[string][]byte) (err er
 	if err := addZipFile(zw, "report.html", htmlBytes); err != nil {
 		return err
 	}
-	if err := addZipFile(zw, "results.json", jsonBytes); err != nil {
+	if err := addZipFile(zw, "summary.json", jsonBytes); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Summary
- rename the evidence bundle's JSON artifact to summary.json and include a trailing newline for readability

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e13877dc2c832c8d0226310a7ed80d