### PR TITLE
Add VPN MTU finding based on regex adapter detection

### DIFF
--- a/cmd/vne-agent/main.go
+++ b/cmd/vne-agent/main.go
@@ -235,7 +235,7 @@ func main() {
 		}
 		findings = append(findings, report.Finding{
 			Severity: "info",
-			Message:  fmt.Sprintf("%s with active VPN/tunnel adapter (%s). Set tunnel MTU to 1420–1412 and enable TCP MSS clamping to avoid fragmentation.", mtuPhrase, strings.Join(vpnAdapters, ", ")),
+			Message:  fmt.Sprintf("%s with active VPN/tunnel adapter (%s). Recommend setting tunnel MTU to 1420–1412 and enabling a TCP MSS clamp to avoid fragmentation.", mtuPhrase, strings.Join(vpnAdapters, ", ")),
 		})
 	}
 

--- a/internal/probes/netinfo.go
+++ b/internal/probes/netinfo.go
@@ -3,6 +3,7 @@ package probes
 import (
 	"net"
 	"os/exec"
+	"regexp"
 	"runtime"
 	"strings"
 )
@@ -25,20 +26,15 @@ type IF struct {
 // VPNAdapterNames returns the set of active interfaces that appear to be
 // VPN/tunnel adapters. This is based on common interface name patterns for
 // popular VPN clients and tunnelling drivers (WireGuard, OpenVPN, etc.).
+var vpnAdapterRegex = regexp.MustCompile(`(?i)(nord|openvpn|wireguard|^tun|^tap|^wg)`)
+
 func (ni NetInfo) VPNAdapterNames() []string {
 	var matches []string
 	for _, iface := range ni.Interfaces {
 		if !iface.Up {
 			continue
 		}
-		nameLower := strings.ToLower(iface.Name)
-		switch {
-		case strings.Contains(nameLower, "nord"),
-			strings.Contains(nameLower, "openvpn"),
-			strings.Contains(nameLower, "wireguard"),
-			strings.HasPrefix(nameLower, "tun"),
-			strings.HasPrefix(nameLower, "tap"),
-			strings.HasPrefix(nameLower, "wg"):
+		if vpnAdapterRegex.MatchString(strings.TrimSpace(iface.Name)) {
 			matches = append(matches, iface.Name)
 		}
 	}


### PR DESCRIPTION
## Summary
- detect active VPN/tunnel adapters using a regex that covers common Nord/OpenVPN/WireGuard/tun/tap/wg names
- when a VPN adapter is present and path MTU is low or unknown, add guidance to set MTU 1420–1412 and clamp TCP MSS

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e1447887f4832ca7f959cfac65be88