### PR TITLE
Update CI workflow for Go 1.22 matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Minimal CI
+name: Cross-platform CI
 
 on:
   push:
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   build:
-    name: build and vet (${{ matrix.os }})
+    name: Go ${{ matrix.go }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -21,11 +21,13 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
+        go:
+          - "1.22"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22.x'
+          go-version: ${{ matrix.go }}
       - name: Go build
         run: go build ./...
       - name: Go vet


### PR DESCRIPTION
## Summary
- update the CI workflow to run against Go 1.22 on Ubuntu, macOS, and Windows
- ensure both go build and go vet execute as part of the matrix jobs

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e151d9e6e0832cbf5ba1bf04517984