### PR TITLE
Add embedded web UI mode

### DIFF
--- a/cmd/vne-agent/run.go
+++ b/cmd/vne-agent/run.go
@@ -1,0 +1,309 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/cneate93/vne/internal/packs"
+	"github.com/cneate93/vne/internal/probes"
+	"github.com/cneate93/vne/internal/report"
+	"github.com/cneate93/vne/internal/snmp"
+	"github.com/cneate93/vne/internal/sshx"
+)
+
+type RunPrinter interface {
+	Println(...interface{})
+	Printf(string, ...interface{})
+}
+
+type stdPrinter struct{}
+
+type nopPrinter struct{}
+
+func (stdPrinter) Println(args ...interface{}) {
+	fmt.Println(args...)
+}
+
+func (stdPrinter) Printf(format string, args ...interface{}) {
+	fmt.Printf(format, args...)
+}
+
+func (nopPrinter) Println(args ...interface{}) {}
+
+func (nopPrinter) Printf(format string, args ...interface{}) {}
+
+type RunOptions struct {
+	Count         int
+	Timeout       time.Duration
+	Scan          bool
+	ScanTimeout   time.Duration
+	ScanMaxHosts  int
+	ScanCIDRLimit int
+	SkipPython    bool
+	AutoPacks     bool
+	SNMPCfg       *snmpQuery
+	Printer       RunPrinter
+}
+
+func runDiagnostics(ctx RunContext, opts RunOptions) (report.Results, error) {
+	printer := opts.Printer
+	if printer == nil {
+		printer = nopPrinter{}
+	}
+	println := func(args ...interface{}) {
+		printer.Println(args...)
+	}
+	printf := func(format string, args ...interface{}) {
+		printer.Printf(format, args...)
+	}
+
+	println("\n→ Collecting local network info…")
+	log.Println("Collecting local network info")
+	netInfo, err := probes.GetBasics()
+	if err != nil {
+		log.Println("netinfo error:", err)
+	}
+
+	gw := netInfo.DefaultGateway
+	if gw == "" && len(netInfo.Gateways) > 0 {
+		gw = netInfo.Gateways[0]
+	}
+
+	var l2Hosts []probes.L2Host
+	if opts.Scan {
+		println("→ Discovering local layer-2 neighbors (ping sweep)…")
+		log.Println("Running layer-2 discovery")
+		l2Hosts, err = probes.L2Scan(opts.ScanTimeout, opts.ScanMaxHosts, opts.ScanCIDRLimit)
+		if err != nil {
+			println("  Unable to complete L2 discovery:", err)
+			log.Println("L2 discovery error:", err)
+		} else if len(l2Hosts) == 0 {
+			println("  No L2 hosts discovered (ARP cache empty).")
+		}
+	} else {
+		println("→ Skipping local layer-2 discovery (enable with --scan).")
+		log.Println("Skipping layer-2 discovery (flag not set)")
+	}
+
+	var gwPing probes.PingResult
+	if gw != "" {
+		println("→ Pinging default gateway:", gw)
+		log.Println("Pinging default gateway", gw)
+		gwPing, _ = probes.PingHost(gw, opts.Count, opts.Timeout)
+	} else {
+		println("→ No default gateway detected; skipping gateway ping.")
+		log.Println("No default gateway detected; skipping gateway ping")
+	}
+
+	println("→ Testing DNS lookups…")
+	log.Println("Testing DNS lookups")
+	dnsLocal, _ := probes.DNSLookupTimed("cloudflare.com", netInfo.DNSServers, opts.Timeout)
+	dnsCF, _ := probes.DNSLookupTimed("cloudflare.com", []string{"1.1.1.1"}, opts.Timeout)
+
+	println("→ Pinging internet target:", ctx.TargetHost)
+	log.Println("Pinging internet target", ctx.TargetHost)
+	wanPing, _ := probes.PingHost(ctx.TargetHost, opts.Count, opts.Timeout)
+
+	println("→ Traceroute (this may take ~10–20 seconds)…")
+	log.Println("Running traceroute")
+	traceOut, _ := probes.Trace(ctx.TargetHost, 20, opts.Timeout)
+
+	println("→ MTU / Path MTU probe…")
+	log.Println("Running MTU / Path MTU probe")
+	mtu, _ := probes.MTUCheck(ctx.TargetHost)
+
+	var autoPackFindings []report.Finding
+	if opts.AutoPacks && !opts.SkipPython {
+		selected := packs.PacksFor(l2Hosts)
+		if len(selected) > 0 {
+			log.Printf("Auto-selected vendor packs: %v", selected)
+		}
+		for _, key := range selected {
+			switch key {
+			case "fortigate":
+				if ctx.FortiHost != "" && ctx.FortiUser != "" && ctx.FortiPass != "" {
+					ctx.UsePythonFortigate = true
+				} else {
+					autoPackFindings = append(autoPackFindings, report.Finding{
+						Severity: "info",
+						Message:  "Detected Fortinet device(s): supply --forti-host, --forti-user, and --forti-pass to run vendor pack.",
+					})
+					log.Println("Detected Fortinet device(s) but missing FortiGate credentials; skipping auto pack run.")
+				}
+			case "cisco_ios":
+				if ctx.CiscoHost != "" && ctx.CiscoUser != "" && ctx.CiscoPass != "" {
+					ctx.UsePythonCisco = true
+				} else {
+					autoPackFindings = append(autoPackFindings, report.Finding{
+						Severity: "info",
+						Message:  "Detected Cisco device(s): supply --cisco-host, --cisco-user, and --cisco-pass to run vendor pack.",
+					})
+					log.Println("Detected Cisco device(s) but missing Cisco IOS credentials; skipping auto pack run.")
+				}
+			}
+		}
+		if (ctx.UsePythonFortigate || ctx.UsePythonCisco) && ctx.PythonPath == "" {
+			ctx.PythonPath = defaultPythonPath()
+		}
+	}
+
+	var fortiRaw map[string]any
+	var ciscoRaw *report.CiscoPackResults
+	if !opts.SkipPython && ctx.UsePythonFortigate {
+		println("→ Running FortiGate Python pack…")
+		log.Println("Running FortiGate Python pack")
+		packDir := filepath.Join("packs", "python", "fortigate")
+		payload := map[string]any{
+			"host":     ctx.FortiHost,
+			"username": ctx.FortiUser,
+			"password": ctx.FortiPass,
+			"commands": map[string]string{
+				"interfaces": "get hardware nic",
+				"routes":     "get router info routing-table all",
+			},
+		}
+		parserPath := filepath.Join(packDir, "parser.py")
+		out, err := sshx.RunPythonPack(ctx.PythonPath, parserPath, payload)
+		if err != nil {
+			log.Println("Forti pack error:", err)
+		} else {
+			_ = json.Unmarshal(out, &fortiRaw)
+		}
+	}
+
+	if !opts.SkipPython && ctx.UsePythonCisco {
+		println("→ Running Cisco IOS Python pack…")
+		log.Println("Running Cisco IOS Python pack")
+		packDir := filepath.Join("packs", "python", "cisco_ios")
+		payload := map[string]any{
+			"host":     ctx.CiscoHost,
+			"username": ctx.CiscoUser,
+			"password": ctx.CiscoPass,
+		}
+		if ctx.CiscoSecret != "" {
+			payload["secret"] = ctx.CiscoSecret
+		}
+		if ctx.CiscoPort != 0 && ctx.CiscoPort != 22 {
+			payload["port"] = ctx.CiscoPort
+		}
+		parserPath := filepath.Join(packDir, "parser.py")
+		out, err := sshx.RunPythonPack(ctx.PythonPath, parserPath, payload)
+		if err != nil {
+			log.Println("Cisco IOS pack error:", err)
+		} else {
+			var parsed report.CiscoPackResults
+			if err := json.Unmarshal(out, &parsed); err != nil {
+				log.Println("Cisco IOS pack parse error:", err)
+			} else {
+				ciscoRaw = &parsed
+			}
+		}
+	}
+
+	var ifaceHealth *snmp.InterfaceHealth
+	if opts.SNMPCfg != nil {
+		println("\n→ Fetching SNMP interface health…")
+		log.Printf("Fetching SNMP interface health from %s (%s)", opts.SNMPCfg.Host, opts.SNMPCfg.Iface)
+		snmpCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		ifaceHealth, err = snmp.GetInterfaceHealth(snmpCtx, opts.SNMPCfg.Host, opts.SNMPCfg.Community, opts.SNMPCfg.Iface)
+		if err != nil {
+			println("  Unable to fetch interface health:", err)
+			log.Println("SNMP interface health error:", err)
+		} else {
+			printf("  Interface %s status: %s\n", ifaceHealth.Name, ifaceHealth.OperStatus)
+			printf("  Speed: %d bps\n", ifaceHealth.SpeedBps)
+			printf("  InErrors=%d OutErrors=%d InDiscards=%d OutDiscards=%d\n",
+				ifaceHealth.InErrors, ifaceHealth.OutErrors, ifaceHealth.InDiscards, ifaceHealth.OutDiscards)
+		}
+	}
+
+	findings := append([]report.Finding{}, autoPackFindings...)
+	if gw != "" && gwPing.Loss > 0.3 {
+		findings = append(findings, report.Finding{
+			Severity: "high",
+			Message:  fmt.Sprintf("High loss to default gateway (%.0f%%). Suspect local wiring/switch port; check cable/port; look for error counters.", gwPing.Loss*100),
+		})
+	}
+	if dnsLocal.AvgMs > 100 && dnsCF.AvgMs > 0 && dnsCF.AvgMs < 50 {
+		findings = append(findings, report.Finding{
+			Severity: "medium",
+			Message:  fmt.Sprintf("Local DNS slow (~%.0f ms). Consider using a public resolver (1.1.1.1) or fixing router DNS forwarder.", dnsLocal.AvgMs),
+		})
+	}
+	if wanPing.Loss > 0.05 {
+		findings = append(findings, report.Finding{
+			Severity: "medium",
+			Message:  fmt.Sprintf("Packet loss to internet target (~%.0f%%). Likely ISP/modem or upstream congestion.", wanPing.Loss*100),
+		})
+	}
+	if mtu.PathMTU > 0 && mtu.PathMTU < 1500 {
+		findings = append(findings, report.Finding{
+			Severity: "info",
+			Message:  fmt.Sprintf("Path MTU appears to be %d. If VPN/tunnel is in path, lower MTU or enable TCP MSS clamping.", mtu.PathMTU),
+		})
+	}
+	vpnAdapters := netInfo.VPNAdapterNames()
+	if len(vpnAdapters) > 0 && (mtu.PathMTU == 0 || mtu.PathMTU < 1500) {
+		mtuPhrase := "Path MTU probe was inconclusive"
+		if mtu.PathMTU > 0 {
+			mtuPhrase = fmt.Sprintf("Path MTU reported as %d", mtu.PathMTU)
+		}
+		findings = append(findings, report.Finding{
+			Severity: "info",
+			Message:  fmt.Sprintf("%s with active VPN/tunnel adapter (%s). Recommend setting tunnel MTU to 1420–1412 and enabling a TCP MSS clamp to avoid fragmentation.", mtuPhrase, strings.Join(vpnAdapters, ", ")),
+		})
+	}
+	if ifaceHealth != nil {
+		if ifaceHealth.OperStatus != "" && strings.ToLower(ifaceHealth.OperStatus) != "up" {
+			findings = append(findings, report.Finding{
+				Severity: "high",
+				Message:  fmt.Sprintf("Interface %s reports operational status %s via SNMP.", ifaceHealth.Name, ifaceHealth.OperStatus),
+			})
+		}
+		if ifaceHealth.InErrors > 0 || ifaceHealth.OutErrors > 0 {
+			findings = append(findings, report.Finding{
+				Severity: "medium",
+				Message:  fmt.Sprintf("Interface %s shows %d input and %d output errors via SNMP.", ifaceHealth.Name, ifaceHealth.InErrors, ifaceHealth.OutErrors),
+			})
+		}
+		if ifaceHealth.InDiscards > 0 || ifaceHealth.OutDiscards > 0 {
+			findings = append(findings, report.Finding{
+				Severity: "medium",
+				Message:  fmt.Sprintf("Interface %s shows %d input and %d output discards via SNMP.", ifaceHealth.Name, ifaceHealth.InDiscards, ifaceHealth.OutDiscards),
+			})
+		}
+	}
+	if ciscoRaw != nil {
+		findings = append(findings, ciscoRaw.Findings...)
+	}
+
+	res := report.Results{
+		When:        time.Now(),
+		UserNote:    ctx.UserNotes,
+		NetInfo:     netInfo,
+		Discovered:  l2Hosts,
+		GwPing:      gwPing,
+		WanPing:     wanPing,
+		DNSLocal:    dnsLocal,
+		DNSCF:       dnsCF,
+		Trace:       traceOut,
+		MTU:         mtu,
+		Findings:    findings,
+		FortiRaw:    fortiRaw,
+		CiscoIOS:    ciscoRaw,
+		IfaceHealth: ifaceHealth,
+		GwLossPct:   fmt.Sprintf("%.0f%%", gwPing.Loss*100),
+		WanLossPct:  fmt.Sprintf("%.0f%%", wanPing.Loss*100),
+		TargetHost:  ctx.TargetHost,
+		HasGateway:  gw != "",
+		GatewayUsed: gw,
+	}
+
+	return res, nil
+}

--- a/internal/webui/index.html
+++ b/internal/webui/index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+        <meta charset="utf-8">
+        <title>Virtual Network Engineer</title>
+        <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+        <main class="container">
+                <header>
+                        <h1>Virtual Network Engineer</h1>
+                        <p class="tagline">Run diagnostics from your browser.</p>
+                </header>
+
+                <section class="card">
+                        <h2>Start a run</h2>
+                        <form id="start-form">
+                                <label class="field">
+                                        <span>Internet target</span>
+                                        <input type="text" name="target" id="target" value="1.1.1.1" autocomplete="off">
+                                </label>
+                                <label class="checkbox">
+                                        <input type="checkbox" name="scan" id="scan">
+                                        <span>Include local layer-2 discovery (experimental)</span>
+                                </label>
+                                <button type="submit">Start diagnostics</button>
+                        </form>
+                        <p id="start-error" class="error" role="alert" hidden></p>
+                </section>
+
+                <section class="card">
+                        <h2>Status</h2>
+                        <div class="status-grid">
+                                <div>
+                                        <span class="label">Phase</span>
+                                        <span id="status-phase">Idle</span>
+                                </div>
+                                <div>
+                                        <span class="label">Progress</span>
+                                        <span id="status-percent">0%</span>
+                                </div>
+                        </div>
+                        <p id="status-message" class="status-message">Ready</p>
+                </section>
+
+                <section class="card">
+                        <h2>Results</h2>
+                        <pre id="results" class="results">(No results yet)</pre>
+                </section>
+        </main>
+        <script src="/static/app.js" defer></script>
+</body>
+</html>

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -1,0 +1,180 @@
+package webui
+
+import (
+	"context"
+	"embed"
+	"encoding/json"
+	"io/fs"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cneate93/vne/internal/report"
+)
+
+//go:embed index.html static/*
+var content embed.FS
+
+type RunRequest struct {
+	Scan   bool   `json:"scan"`
+	Target string `json:"target"`
+}
+
+type RunFunc func(context.Context, RunRequest) (report.Results, error)
+
+type Server struct {
+	runner RunFunc
+	mux    *http.ServeMux
+
+	mu    sync.Mutex
+	state runState
+	files http.Handler
+}
+
+type runState struct {
+	phase   string
+	percent float64
+	message string
+	running bool
+	results *report.Results
+}
+
+func NewServer(runner RunFunc) (*Server, error) {
+	staticFS, err := fs.Sub(content, "static")
+	if err != nil {
+		return nil, err
+	}
+	srv := &Server{
+		runner: runner,
+		files:  http.FileServer(http.FS(staticFS)),
+		state: runState{
+			phase:   "idle",
+			percent: 0,
+			message: "Ready",
+		},
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", srv.handleIndex)
+	mux.Handle("/static/", http.StripPrefix("/static/", srv.files))
+	mux.HandleFunc("/api/start", srv.handleStart)
+	mux.HandleFunc("/api/status", srv.handleStatus)
+	mux.HandleFunc("/api/results", srv.handleResults)
+	srv.mux = mux
+	return srv, nil
+}
+
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.mux.ServeHTTP(w, r)
+}
+
+func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	data, err := content.ReadFile("index.html")
+	if err != nil {
+		http.Error(w, "unable to load UI", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = w.Write(data)
+}
+
+func (s *Server) handleStart(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req RunRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid JSON payload", http.StatusBadRequest)
+		return
+	}
+	req.Target = strings.TrimSpace(req.Target)
+	if req.Target == "" {
+		req.Target = "1.1.1.1"
+	}
+
+	s.mu.Lock()
+	if s.state.running {
+		s.mu.Unlock()
+		http.Error(w, "run already in progress", http.StatusConflict)
+		return
+	}
+	s.state.running = true
+	s.state.phase = "running"
+	s.state.percent = 5
+	s.state.message = "Starting diagnostics…"
+	s.state.results = nil
+	s.mu.Unlock()
+
+	go s.execute(req)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	json.NewEncoder(w).Encode(map[string]string{"status": "started"})
+}
+
+func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	s.mu.Lock()
+	status := Status{
+		Phase:   s.state.phase,
+		Percent: s.state.percent,
+		Message: s.state.message,
+	}
+	s.mu.Unlock()
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(status)
+}
+
+func (s *Server) handleResults(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	s.mu.Lock()
+	res := s.state.results
+	phase := s.state.phase
+	s.mu.Unlock()
+	if res == nil || phase != "finished" {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(res)
+}
+
+func (s *Server) execute(req RunRequest) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
+	res, err := s.runner(ctx, req)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err != nil {
+		s.state.phase = "error"
+		s.state.percent = 100
+		s.state.message = err.Error()
+		s.state.running = false
+		s.state.results = nil
+		return
+	}
+	resCopy := res
+	s.state.phase = "finished"
+	s.state.percent = 100
+	s.state.message = "Diagnostics complete"
+	s.state.running = false
+	s.state.results = &resCopy
+}
+
+type Status struct {
+	Phase   string  `json:"phase"`
+	Percent float64 `json:"percent"`
+	Message string  `json:"message"`
+}

--- a/internal/webui/static/app.js
+++ b/internal/webui/static/app.js
@@ -1,0 +1,96 @@
+(() => {
+        const form = document.getElementById('start-form');
+        const targetInput = document.getElementById('target');
+        const scanInput = document.getElementById('scan');
+        const statusPhase = document.getElementById('status-phase');
+        const statusPercent = document.getElementById('status-percent');
+        const statusMessage = document.getElementById('status-message');
+        const resultsEl = document.getElementById('results');
+        const startError = document.getElementById('start-error');
+
+        let pollTimer = null;
+
+        async function updateStatus() {
+                try {
+                        const resp = await fetch('/api/status');
+                        if (!resp.ok) {
+                                throw new Error('Status request failed');
+                        }
+                        const data = await resp.json();
+                        statusPhase.textContent = data.phase || 'unknown';
+                        statusPercent.textContent = `${Math.round((data.percent ?? 0) * 10) / 10}%`;
+                        statusMessage.textContent = data.message || '';
+
+                        if (data.phase === 'finished') {
+                                clearInterval(pollTimer);
+                                pollTimer = null;
+                                await loadResults();
+                        } else if (data.phase === 'error') {
+                                clearInterval(pollTimer);
+                                pollTimer = null;
+                                resultsEl.textContent = '(Run failed)';
+                        }
+                } catch (err) {
+                        console.error(err);
+                }
+        }
+
+        async function loadResults() {
+                try {
+                        const resp = await fetch('/api/results');
+                        if (!resp.ok) {
+                                resultsEl.textContent = '(Results not available yet)';
+                                return;
+                        }
+                        const data = await resp.json();
+                        resultsEl.textContent = JSON.stringify(data, null, 2);
+                } catch (err) {
+                        console.error(err);
+                        resultsEl.textContent = '(Unable to load results)';
+                }
+        }
+
+        form.addEventListener('submit', async (event) => {
+                event.preventDefault();
+                startError.hidden = true;
+                startError.textContent = '';
+
+                const payload = {
+                        target: targetInput.value.trim(),
+                        scan: scanInput.checked,
+                };
+
+                try {
+                        const resp = await fetch('/api/start', {
+                                method: 'POST',
+                                headers: { 'Content-Type': 'application/json' },
+                                body: JSON.stringify(payload),
+                        });
+                        if (resp.status === 409) {
+                                startError.textContent = 'A run is already in progress.';
+                                startError.hidden = false;
+                                return;
+                        }
+                        if (!resp.ok) {
+                                startError.textContent = 'Unable to start diagnostics.';
+                                startError.hidden = false;
+                                return;
+                        }
+                        resultsEl.textContent = '(Working…)';
+                        statusPhase.textContent = 'running';
+                        statusPercent.textContent = '5%';
+                        statusMessage.textContent = 'Starting diagnostics…';
+                        if (pollTimer) {
+                                clearInterval(pollTimer);
+                        }
+                        pollTimer = setInterval(updateStatus, 1500);
+                        await updateStatus();
+                } catch (err) {
+                        console.error(err);
+                        startError.textContent = 'Unexpected error starting diagnostics.';
+                        startError.hidden = false;
+                }
+        });
+
+        updateStatus();
+})();

--- a/internal/webui/static/style.css
+++ b/internal/webui/static/style.css
@@ -1,0 +1,126 @@
+:root {
+        color-scheme: light dark;
+        font-family: "Segoe UI", Roboto, sans-serif;
+        background-color: #f5f7fb;
+        color: #1f2933;
+}
+
+body {
+        margin: 0;
+        padding: 0;
+}
+
+.container {
+        max-width: 900px;
+        margin: 0 auto;
+        padding: 2rem 1.5rem 3rem;
+}
+
+header {
+        margin-bottom: 1.5rem;
+        text-align: center;
+}
+
+h1 {
+        margin: 0;
+        font-size: 2.25rem;
+}
+
+.tagline {
+        margin: 0.5rem 0 0;
+        color: #52606d;
+}
+
+.card {
+        background: rgba(255, 255, 255, 0.9);
+        border-radius: 12px;
+        padding: 1.5rem;
+        box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+        margin-bottom: 1.5rem;
+}
+
+.card h2 {
+        margin-top: 0;
+        font-size: 1.4rem;
+}
+
+.field {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        margin-bottom: 1rem;
+}
+
+.field input[type="text"] {
+        padding: 0.65rem 0.75rem;
+        border-radius: 8px;
+        border: 1px solid #cbd2d9;
+        font-size: 1rem;
+}
+
+.checkbox {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        margin-bottom: 1rem;
+}
+
+button {
+        appearance: none;
+        background-color: #2563eb;
+        border: none;
+        color: #fff;
+        padding: 0.7rem 1.5rem;
+        border-radius: 999px;
+        font-size: 1rem;
+        cursor: pointer;
+        transition: background-color 0.2s ease;
+}
+
+button:hover {
+        background-color: #1d4ed8;
+}
+
+.status-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+        gap: 1rem;
+        margin-bottom: 0.75rem;
+}
+
+.label {
+        display: block;
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: #8899a6;
+        margin-bottom: 0.35rem;
+}
+
+.status-message {
+        margin: 0;
+        font-size: 1rem;
+}
+
+.results {
+        margin: 0;
+        max-height: 400px;
+        overflow: auto;
+        background: #0f172a;
+        color: #f8fafc;
+        border-radius: 8px;
+        padding: 1rem;
+        font-size: 0.9rem;
+        line-height: 1.45;
+}
+
+.error {
+        color: #b91c1c;
+        margin-top: 0.75rem;
+}
+
+@media (max-width: 640px) {
+        .container {
+                padding: 1.5rem 1rem 2rem;
+        }
+}


### PR DESCRIPTION
## Summary
- add a `--web` flag that launches the embedded web UI on 127.0.0.1:8080
- refactor the diagnostic pipeline into a reusable `runDiagnostics` helper for CLI and web flows
- add an embedded HTML/JS/CSS UI and REST API handlers under `internal/webui`

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e1743c8374832cb8a555881a295d54