### PR TITLE
Add SSE progress stream to web UI

### DIFF
--- a/cmd/vne-agent/main.go
+++ b/cmd/vne-agent/main.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/cneate93/vne/internal/logx"
+	"github.com/cneate93/vne/internal/progress"
 	"github.com/cneate93/vne/internal/report"
 	"github.com/cneate93/vne/internal/webui"
 )
@@ -166,7 +167,7 @@ func main() {
 	autoPacksRequested := *autoPacksFlag
 
 	if *webFlag {
-		srv, err := webui.NewServer(func(_ context.Context, req webui.RunRequest) (report.Results, error) {
+		srv, err := webui.NewServer(func(_ context.Context, req webui.RunRequest, reporter progress.Reporter) (report.Results, error) {
 			runCtx := RunContext{
 				TargetHost: "1.1.1.1",
 				CiscoPort:  22,
@@ -184,7 +185,8 @@ func main() {
 				SkipPython:    true,
 				AutoPacks:     false,
 				SNMPCfg:       nil,
-				Printer:       nopPrinter{},
+				Printer:       newProgressPrinter(reporter),
+				Progress:      reporter,
 			}
 			return runDiagnostics(runCtx, opts)
 		})

--- a/internal/progress/progress.go
+++ b/internal/progress/progress.go
@@ -1,0 +1,9 @@
+package progress
+
+// Reporter receives structured updates about a running diagnostics session.
+type Reporter interface {
+	// Phase marks the transition to a new high-level phase of the run.
+	Phase(name string)
+	// Step records a human-readable message for the live console output.
+	Step(msg string)
+}

--- a/internal/webui/index.html
+++ b/internal/webui/index.html
@@ -40,7 +40,17 @@
                                         <span id="status-percent">0%</span>
                                 </div>
                         </div>
+                        <div class="progress" aria-hidden="true">
+                                <div class="progress-bar" id="progress-bar"></div>
+                        </div>
                         <p id="status-message" class="status-message">Ready</p>
+                </section>
+
+                <section class="card">
+                        <h2>Console</h2>
+                        <div id="console" class="console" aria-live="polite" aria-atomic="false">
+                                <div class="console-empty">No activity yet.</div>
+                        </div>
                 </section>
 
                 <section class="card">

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"embed"
 	"encoding/json"
+	"fmt"
 	"io/fs"
 	"net/http"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/cneate93/vne/internal/progress"
 	"github.com/cneate93/vne/internal/report"
 )
 
@@ -21,7 +23,7 @@ type RunRequest struct {
 	Target string `json:"target"`
 }
 
-type RunFunc func(context.Context, RunRequest) (report.Results, error)
+type RunFunc func(context.Context, RunRequest, progress.Reporter) (report.Results, error)
 
 type Server struct {
 	runner RunFunc
@@ -30,6 +32,9 @@ type Server struct {
 	mu    sync.Mutex
 	state runState
 	files http.Handler
+
+	subsMu sync.Mutex
+	subs   map[chan streamEvent]struct{}
 }
 
 type runState struct {
@@ -38,6 +43,31 @@ type runState struct {
 	message string
 	running bool
 	results *report.Results
+	log     []streamEvent
+}
+
+type streamEvent struct {
+	event string
+	data  string
+}
+
+const maxStreamLog = 500
+
+var phasePercents = map[string]float64{
+	"idle":         0,
+	"starting":     5,
+	"netinfo":      12,
+	"l2-scan":      25,
+	"gateway":      38,
+	"dns":          52,
+	"wan":          68,
+	"traceroute":   80,
+	"mtu":          88,
+	"python-packs": 94,
+	"snmp":         97,
+	"finalizing":   99,
+	"finished":     100,
+	"error":        100,
 }
 
 func NewServer(runner RunFunc) (*Server, error) {
@@ -53,6 +83,7 @@ func NewServer(runner RunFunc) (*Server, error) {
 			percent: 0,
 			message: "Ready",
 		},
+		subs: make(map[chan streamEvent]struct{}),
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", srv.handleIndex)
@@ -60,7 +91,9 @@ func NewServer(runner RunFunc) (*Server, error) {
 	mux.HandleFunc("/api/start", srv.handleStart)
 	mux.HandleFunc("/api/status", srv.handleStatus)
 	mux.HandleFunc("/api/results", srv.handleResults)
+	mux.HandleFunc("/api/stream", srv.handleStream)
 	srv.mux = mux
+	srv.recordPhase("idle", "Ready", false)
 	return srv, nil
 }
 
@@ -104,11 +137,15 @@ func (s *Server) handleStart(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.state.running = true
-	s.state.phase = "running"
+	s.state.phase = "starting"
 	s.state.percent = 5
 	s.state.message = "Starting diagnostics…"
 	s.state.results = nil
+	s.state.log = nil
 	s.mu.Unlock()
+
+	s.recordPhase("starting", "Starting diagnostics…", true)
+	s.recordStep("Starting diagnostics…")
 
 	go s.execute(req)
 
@@ -153,16 +190,20 @@ func (s *Server) handleResults(w http.ResponseWriter, r *http.Request) {
 func (s *Server) execute(req RunRequest) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 	defer cancel()
-	res, err := s.runner(ctx, req)
+	progress := &progressEmitter{server: s}
+	res, err := s.runner(ctx, req, progress)
 
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	if err != nil {
 		s.state.phase = "error"
 		s.state.percent = 100
 		s.state.message = err.Error()
 		s.state.running = false
 		s.state.results = nil
+		s.mu.Unlock()
+		s.recordPhase("error", err.Error(), false)
+		s.recordStep(fmt.Sprintf("Run failed: %s", err.Error()))
+		s.recordDone("error", err.Error())
 		return
 	}
 	resCopy := res
@@ -171,10 +212,159 @@ func (s *Server) execute(req RunRequest) {
 	s.state.message = "Diagnostics complete"
 	s.state.running = false
 	s.state.results = &resCopy
+	s.mu.Unlock()
+	s.recordPhase("finished", "Diagnostics complete", false)
+	s.recordStep("Diagnostics complete.")
+	s.recordDone("finished", "Diagnostics complete")
 }
 
 type Status struct {
 	Phase   string  `json:"phase"`
 	Percent float64 `json:"percent"`
 	Message string  `json:"message"`
+}
+
+func (s *Server) handleStream(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	ch := make(chan streamEvent, 32)
+	s.addSubscriber(ch)
+	defer s.removeSubscriber(ch)
+
+	s.mu.Lock()
+	history := append([]streamEvent(nil), s.state.log...)
+	s.mu.Unlock()
+
+	for _, evt := range history {
+		fmt.Fprintf(w, "event: %s\n", evt.event)
+		fmt.Fprintf(w, "data: %s\n\n", evt.data)
+	}
+	flusher.Flush()
+
+	notify := r.Context().Done()
+	for {
+		select {
+		case <-notify:
+			return
+		case evt, ok := <-ch:
+			if !ok {
+				return
+			}
+			fmt.Fprintf(w, "event: %s\n", evt.event)
+			fmt.Fprintf(w, "data: %s\n\n", evt.data)
+			flusher.Flush()
+		}
+	}
+}
+
+func (s *Server) addSubscriber(ch chan streamEvent) {
+	s.subsMu.Lock()
+	s.subs[ch] = struct{}{}
+	s.subsMu.Unlock()
+}
+
+func (s *Server) removeSubscriber(ch chan streamEvent) {
+	s.subsMu.Lock()
+	if _, ok := s.subs[ch]; ok {
+		delete(s.subs, ch)
+		close(ch)
+	}
+	s.subsMu.Unlock()
+}
+
+func (s *Server) recordPhase(name, message string, reset bool) {
+	s.mu.Lock()
+	if reset {
+		s.state.log = nil
+	}
+	s.state.phase = name
+	if pct, ok := phasePercents[name]; ok {
+		s.state.percent = pct
+	}
+	if message != "" {
+		s.state.message = message
+	}
+	percent := s.state.percent
+	currentMessage := s.state.message
+	s.mu.Unlock()
+
+	payload := map[string]any{
+		"name":    name,
+		"percent": percent,
+	}
+	if currentMessage != "" {
+		payload["message"] = currentMessage
+	}
+	if reset {
+		payload["reset"] = true
+	}
+	s.broadcast("phase", payload, reset)
+}
+
+func (s *Server) recordStep(msg string) {
+	if msg == "" {
+		return
+	}
+	s.mu.Lock()
+	s.state.message = msg
+	s.mu.Unlock()
+	s.broadcast("step", map[string]any{"msg": msg}, false)
+}
+
+func (s *Server) recordDone(status, message string) {
+	payload := map[string]any{"status": status}
+	if message != "" {
+		payload["message"] = message
+	}
+	s.broadcast("done", payload, false)
+}
+
+func (s *Server) broadcast(event string, payload any, reset bool) {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return
+	}
+	evt := streamEvent{event: event, data: string(data)}
+	s.mu.Lock()
+	if reset {
+		s.state.log = nil
+	}
+	s.state.log = append(s.state.log, evt)
+	if len(s.state.log) > maxStreamLog {
+		s.state.log = s.state.log[len(s.state.log)-maxStreamLog:]
+	}
+	s.mu.Unlock()
+
+	s.subsMu.Lock()
+	for ch := range s.subs {
+		select {
+		case ch <- evt:
+		default:
+		}
+	}
+	s.subsMu.Unlock()
+}
+
+type progressEmitter struct {
+	server *Server
+}
+
+func (p *progressEmitter) Phase(name string) {
+	p.server.recordPhase(name, "", false)
+}
+
+func (p *progressEmitter) Step(msg string) {
+	p.server.recordStep(msg)
 }

--- a/internal/webui/static/app.js
+++ b/internal/webui/static/app.js
@@ -7,8 +7,40 @@
         const statusMessage = document.getElementById('status-message');
         const resultsEl = document.getElementById('results');
         const startError = document.getElementById('start-error');
+        const consoleEl = document.getElementById('console');
+        const progressBar = document.getElementById('progress-bar');
 
-        let pollTimer = null;
+        const PHASE_LABELS = {
+                idle: 'Idle',
+                starting: 'Starting',
+                netinfo: 'Network info',
+                'l2-scan': 'Layer-2 scan',
+                gateway: 'Gateway checks',
+                dns: 'DNS lookups',
+                wan: 'WAN ping',
+                traceroute: 'Traceroute',
+                mtu: 'MTU probe',
+                'python-packs': 'Vendor packs',
+                snmp: 'SNMP',
+                finalizing: 'Finalizing',
+                finished: 'Finished',
+                error: 'Error',
+        };
+
+        let eventSource = null;
+
+        function ensureStream() {
+                if (eventSource) {
+                        return;
+                }
+                eventSource = new EventSource('/api/stream');
+                eventSource.addEventListener('phase', handlePhaseEvent);
+                eventSource.addEventListener('step', handleStepEvent);
+                eventSource.addEventListener('done', handleDoneEvent);
+                eventSource.onerror = () => {
+                        // Let EventSource reconnect automatically.
+                };
+        }
 
         async function updateStatus() {
                 try {
@@ -17,18 +49,10 @@
                                 throw new Error('Status request failed');
                         }
                         const data = await resp.json();
-                        statusPhase.textContent = data.phase || 'unknown';
-                        statusPercent.textContent = `${Math.round((data.percent ?? 0) * 10) / 10}%`;
-                        statusMessage.textContent = data.message || '';
-
-                        if (data.phase === 'finished') {
-                                clearInterval(pollTimer);
-                                pollTimer = null;
-                                await loadResults();
-                        } else if (data.phase === 'error') {
-                                clearInterval(pollTimer);
-                                pollTimer = null;
-                                resultsEl.textContent = '(Run failed)';
+                        applyPhase(data.phase || 'idle');
+                        setProgress(data.percent ?? 0);
+                        if (data.message) {
+                                statusMessage.textContent = data.message;
                         }
                 } catch (err) {
                         console.error(err);
@@ -77,14 +101,9 @@
                                 return;
                         }
                         resultsEl.textContent = '(Working…)';
-                        statusPhase.textContent = 'running';
-                        statusPercent.textContent = '5%';
                         statusMessage.textContent = 'Starting diagnostics…';
-                        if (pollTimer) {
-                                clearInterval(pollTimer);
-                        }
-                        pollTimer = setInterval(updateStatus, 1500);
-                        await updateStatus();
+                        applyPhase('starting');
+                        setProgress(5);
                 } catch (err) {
                         console.error(err);
                         startError.textContent = 'Unexpected error starting diagnostics.';
@@ -92,5 +111,99 @@
                 }
         });
 
+        function applyPhase(phase) {
+                const label = PHASE_LABELS[phase] || phase || 'unknown';
+                statusPhase.textContent = label;
+        }
+
+        function setProgress(value) {
+                const percent = Number.isFinite(value) ? value : 0;
+                const clamped = Math.max(0, Math.min(100, percent));
+                const display = Math.round(clamped * 10) / 10;
+                statusPercent.textContent = `${display}%`;
+                if (progressBar) {
+                        progressBar.style.width = `${clamped}%`;
+                }
+        }
+
+        function clearConsole() {
+                if (!consoleEl) {
+                        return;
+                }
+                consoleEl.innerHTML = '';
+                const empty = document.createElement('div');
+                empty.className = 'console-empty';
+                empty.textContent = 'No activity yet.';
+                consoleEl.appendChild(empty);
+        }
+
+        function appendConsole(msg) {
+                if (!consoleEl || !msg) {
+                        return;
+                }
+                const first = consoleEl.firstElementChild;
+                if (first && first.classList.contains('console-empty')) {
+                        consoleEl.innerHTML = '';
+                }
+                const line = document.createElement('div');
+                line.className = 'console-line';
+                line.textContent = msg;
+                consoleEl.appendChild(line);
+                consoleEl.scrollTop = consoleEl.scrollHeight;
+        }
+
+        function parseEventData(raw) {
+                try {
+                        return JSON.parse(raw);
+                } catch (err) {
+                        console.error('Unable to parse event payload', err);
+                        return null;
+                }
+        }
+
+        function handlePhaseEvent(event) {
+                const data = parseEventData(event.data);
+                if (!data) {
+                        return;
+                }
+                if (data.reset) {
+                        clearConsole();
+                }
+                if (data.name) {
+                        applyPhase(data.name);
+                }
+                if (typeof data.percent === 'number') {
+                        setProgress(data.percent);
+                }
+                if (typeof data.message === 'string') {
+                        statusMessage.textContent = data.message;
+                }
+        }
+
+        function handleStepEvent(event) {
+                const data = parseEventData(event.data);
+                if (!data || typeof data.msg !== 'string') {
+                        return;
+                }
+                appendConsole(data.msg);
+                statusMessage.textContent = data.msg;
+        }
+
+        async function handleDoneEvent(event) {
+                const data = parseEventData(event.data);
+                if (!data) {
+                        return;
+                }
+                if (data.message) {
+                        statusMessage.textContent = data.message;
+                }
+                if (data.status === 'finished') {
+                        await loadResults();
+                } else if (data.status === 'error') {
+                        resultsEl.textContent = '(Run failed)';
+                }
+        }
+
+        ensureStream();
         updateStatus();
 })();

--- a/internal/webui/static/style.css
+++ b/internal/webui/static/style.css
@@ -102,6 +102,54 @@ button:hover {
         font-size: 1rem;
 }
 
+.progress {
+        width: 100%;
+        height: 8px;
+        background: #e2e8f0;
+        border-radius: 999px;
+        overflow: hidden;
+        margin: 0.35rem 0 0.9rem;
+        position: relative;
+}
+
+.progress-bar {
+        height: 100%;
+        width: 0%;
+        background: linear-gradient(90deg, #2563eb, #4f46e5);
+        transition: width 0.3s ease;
+}
+
+.console {
+        margin: 0;
+        background: #0f172a;
+        color: #f8fafc;
+        border-radius: 8px;
+        padding: 1rem;
+        font-family: "SFMono-Regular", "Consolas", "Liberation Mono", monospace;
+        font-size: 0.85rem;
+        line-height: 1.45;
+        max-height: 260px;
+        overflow-y: auto;
+        box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.2);
+}
+
+.console div {
+        white-space: pre-wrap;
+}
+
+.console-line {
+        margin: 0 0 0.3rem;
+}
+
+.console-line:last-child {
+        margin-bottom: 0;
+}
+
+.console-empty {
+        color: #94a3b8;
+        font-style: italic;
+}
+
 .results {
         margin: 0;
         max-height: 400px;


### PR DESCRIPTION
## Summary
- add an SSE endpoint at /api/stream and broadcast run phases, steps, and completion
- thread structured progress reporting through the diagnostics runner
- refresh the web UI with a live console, progress bar, and EventSource client

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e1780c41dc832c914c4f39cd1f84d4