### PR TITLE
Add LAN and WAN performance metrics and UI cards

### DIFF
--- a/assets/report_template.html
+++ b/assets/report_template.html
@@ -102,9 +102,9 @@
 
   <h2>Connectivity Checks</h2>
   <table>
-    <tr><th>Check</th><th>Target</th><th>Avg</th><th>Loss</th><th>Jitter</th></tr>
-    <tr><td>Gateway Ping</td><td>{{ if .HasGateway }}{{ .GatewayUsed }}{{ else }}(n/a){{ end }}</td><td>{{ ms1 .GwPing.AvgMs }}</td><td>{{ pct .GwPing.Loss }}</td><td>{{ ms1 .GwJitterMs }}</td></tr>
-    <tr><td>WAN Ping</td><td>{{ .TargetHost }}</td><td>{{ ms1 .WanPing.AvgMs }}</td><td>{{ pct .WanPing.Loss }}</td><td>{{ ms1 .WanJitterMs }}</td></tr>
+    <tr><th>Check</th><th>Target</th><th>Avg</th><th>95th %</th><th>Loss</th><th>Jitter</th></tr>
+    <tr><td>Gateway Ping</td><td>{{ if .HasGateway }}{{ .GatewayUsed }}{{ else }}(n/a){{ end }}</td><td>{{ ms1 .GwPing.AvgMs }}</td><td>{{ ms1 .GwPing.P95Ms }}</td><td>{{ pct .GwPing.Loss }}</td><td>{{ ms1 .GwJitterMs }}</td></tr>
+    <tr><td>WAN Ping</td><td>{{ .TargetHost }}</td><td>{{ ms1 .WanPing.AvgMs }}</td><td>{{ ms1 .WanPing.P95Ms }}</td><td>{{ pct .WanPing.Loss }}</td><td>{{ ms1 .WanJitterMs }}</td></tr>
   </table>
 
   <h2>DNS</h2>

--- a/internal/report/report_template.html
+++ b/internal/report/report_template.html
@@ -87,9 +87,9 @@
 
   <h2>Connectivity Checks</h2>
   <table>
-    <tr><th>Check</th><th>Target</th><th>Avg</th><th>Loss</th><th>Jitter</th></tr>
-    <tr><td>Gateway Ping</td><td>{{ if .HasGateway }}{{ .GatewayUsed }}{{ else }}(n/a){{ end }}</td><td>{{ ms1 .GwPing.AvgMs }}</td><td>{{ pct .GwPing.Loss }}</td><td>{{ ms1 .GwJitterMs }}</td></tr>
-    <tr><td>WAN Ping</td><td>{{ .TargetHost }}</td><td>{{ ms1 .WanPing.AvgMs }}</td><td>{{ pct .WanPing.Loss }}</td><td>{{ ms1 .WanJitterMs }}</td></tr>
+    <tr><th>Check</th><th>Target</th><th>Avg</th><th>95th %</th><th>Loss</th><th>Jitter</th></tr>
+    <tr><td>Gateway Ping</td><td>{{ if .HasGateway }}{{ .GatewayUsed }}{{ else }}(n/a){{ end }}</td><td>{{ ms1 .GwPing.AvgMs }}</td><td>{{ ms1 .GwPing.P95Ms }}</td><td>{{ pct .GwPing.Loss }}</td><td>{{ ms1 .GwJitterMs }}</td></tr>
+    <tr><td>WAN Ping</td><td>{{ .TargetHost }}</td><td>{{ ms1 .WanPing.AvgMs }}</td><td>{{ ms1 .WanPing.P95Ms }}</td><td>{{ pct .WanPing.Loss }}</td><td>{{ ms1 .WanJitterMs }}</td></tr>
   </table>
 
   <h2>DNS</h2>

--- a/internal/webui/index.html
+++ b/internal/webui/index.html
@@ -46,6 +46,44 @@
                         <p id="status-message" class="status-message">Ready</p>
                 </section>
 
+                <section class="card" id="lan-card" hidden>
+                        <h2>LAN Performance</h2>
+                        <p class="card-subtitle">Default gateway: <span id="lan-dest">(detecting…)</span></p>
+                        <div class="metric-grid">
+                                <div class="metric">
+                                        <span class="label">Avg RTT</span>
+                                        <span id="lan-avg" class="metric-value">—</span>
+                                </div>
+                                <div class="metric">
+                                        <span class="label">95th Percentile</span>
+                                        <span id="lan-p95" class="metric-value">—</span>
+                                </div>
+                                <div class="metric">
+                                        <span class="label">Jitter</span>
+                                        <span id="lan-jitter" class="metric-value">—</span>
+                                </div>
+                        </div>
+                </section>
+
+                <section class="card" id="wan-card" hidden>
+                        <h2>WAN Performance</h2>
+                        <p class="card-subtitle">Target host: <span id="wan-dest">(detecting…)</span></p>
+                        <div class="metric-grid">
+                                <div class="metric">
+                                        <span class="label">Avg RTT</span>
+                                        <span id="wan-avg" class="metric-value">—</span>
+                                </div>
+                                <div class="metric">
+                                        <span class="label">95th Percentile</span>
+                                        <span id="wan-p95" class="metric-value">—</span>
+                                </div>
+                                <div class="metric">
+                                        <span class="label">Jitter</span>
+                                        <span id="wan-jitter" class="metric-value">—</span>
+                                </div>
+                        </div>
+                </section>
+
                 <section class="card">
                         <h2>Console</h2>
                         <div id="console" class="console" aria-live="polite" aria-atomic="false">

--- a/internal/webui/static/app.js
+++ b/internal/webui/static/app.js
@@ -9,6 +9,16 @@
         const startError = document.getElementById('start-error');
         const consoleEl = document.getElementById('console');
         const progressBar = document.getElementById('progress-bar');
+        const lanCard = document.getElementById('lan-card');
+        const lanDest = document.getElementById('lan-dest');
+        const lanAvg = document.getElementById('lan-avg');
+        const lanP95 = document.getElementById('lan-p95');
+        const lanJitter = document.getElementById('lan-jitter');
+        const wanCard = document.getElementById('wan-card');
+        const wanDest = document.getElementById('wan-dest');
+        const wanAvg = document.getElementById('wan-avg');
+        const wanP95 = document.getElementById('wan-p95');
+        const wanJitter = document.getElementById('wan-jitter');
 
         const PHASE_LABELS = {
                 idle: 'Idle',
@@ -62,15 +72,22 @@
         async function loadResults() {
                 try {
                         const resp = await fetch('/api/results');
+                        if (resp.status === 204) {
+                                resultsEl.textContent = '(Results not available yet)';
+                                populatePerformanceCards(null);
+                                return;
+                        }
                         if (!resp.ok) {
                                 resultsEl.textContent = '(Results not available yet)';
                                 return;
                         }
                         const data = await resp.json();
                         resultsEl.textContent = JSON.stringify(data, null, 2);
+                        populatePerformanceCards(data);
                 } catch (err) {
                         console.error(err);
                         resultsEl.textContent = '(Unable to load results)';
+                        populatePerformanceCards(null);
                 }
         }
 
@@ -201,6 +218,70 @@
                         await loadResults();
                 } else if (data.status === 'error') {
                         resultsEl.textContent = '(Run failed)';
+                        populatePerformanceCards(null);
+                }
+        }
+
+        function formatMs(value) {
+                if (!Number.isFinite(value) || value < 0) {
+                        return '—';
+                }
+                const decimals = value >= 10 ? 0 : 1;
+                return `${value.toFixed(decimals)} ms`;
+        }
+
+        function populatePerformanceCards(data) {
+                if (lanCard) {
+                        if (!data || !data.has_gateway) {
+                                lanCard.hidden = true;
+                        } else {
+                                updatePerformanceCard(
+                                        lanCard,
+                                        lanDest,
+                                        lanAvg,
+                                        lanP95,
+                                        lanJitter,
+                                        data.gw_ping,
+                                        data.gw_jitter_ms,
+                                        data.gateway_used || '(unknown)'
+                                );
+                        }
+                }
+                if (wanCard) {
+                        updatePerformanceCard(
+                                wanCard,
+                                wanDest,
+                                wanAvg,
+                                wanP95,
+                                wanJitter,
+                                data ? data.wan_ping : null,
+                                data ? data.wan_jitter_ms : undefined,
+                                data && data.target_host ? data.target_host : '(unknown)'
+                        );
+                }
+        }
+
+        function updatePerformanceCard(card, destEl, avgEl, p95El, jitterEl, ping, fallbackJitter, destination) {
+                if (!card) {
+                        return;
+                }
+                if (!ping || typeof ping !== 'object') {
+                        card.hidden = true;
+                        return;
+                }
+                card.hidden = false;
+                if (destEl) {
+                        destEl.textContent = destination || '(unknown)';
+                }
+                if (avgEl) {
+                        avgEl.textContent = formatMs(ping.avg_ms);
+                }
+                if (p95El) {
+                        p95El.textContent = formatMs(ping.p95_ms);
+                }
+                const jitterValue = Number.isFinite(ping.jitter_ms) ? ping.jitter_ms : fallbackJitter;
+                if (jitterEl) {
+                        jitterEl.textContent = formatMs(jitterValue);
                 }
         }
 

--- a/internal/webui/static/style.css
+++ b/internal/webui/static/style.css
@@ -44,6 +44,31 @@ h1 {
         font-size: 1.4rem;
 }
 
+.card-subtitle {
+        margin: 0.3rem 0 1.1rem;
+        color: #52606d;
+        font-size: 0.95rem;
+}
+
+.metric-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+        gap: 1rem;
+}
+
+.metric {
+        background: rgba(37, 99, 235, 0.08);
+        border-radius: 12px;
+        padding: 0.85rem 1rem;
+}
+
+.metric-value {
+        display: block;
+        font-size: 1.5rem;
+        font-weight: 600;
+        color: inherit;
+}
+
 .field {
         display: flex;
         flex-direction: column;

--- a/packs/python/fortigate/parser.py
+++ b/packs/python/fortigate/parser.py
@@ -73,9 +73,9 @@
 
   <h2>Connectivity Checks</h2>
   <table>
-    <tr><th>Check</th><th>Target</th><th>Avg (ms)</th><th>Loss</th><th>Jitter (ms)</th></tr>
-    <tr><td>Gateway Ping</td><td>{{ if .HasGateway }}{{ .GatewayUsed }}{{ else }}(n/a){{ end }}</td><td>{{ printf "%.1f" .GwPing.AvgMs }}</td><td>{{ .GwLossPct }}</td><td>{{ printf "%.1f" .GwJitterMs }}</td></tr>
-    <tr><td>WAN Ping</td><td>{{ .TargetHost }}</td><td>{{ printf "%.1f" .WanPing.AvgMs }}</td><td>{{ .WanLossPct }}</td><td>{{ printf "%.1f" .WanJitterMs }}</td></tr>
+    <tr><th>Check</th><th>Target</th><th>Avg (ms)</th><th>95th % (ms)</th><th>Loss</th><th>Jitter (ms)</th></tr>
+    <tr><td>Gateway Ping</td><td>{{ if .HasGateway }}{{ .GatewayUsed }}{{ else }}(n/a){{ end }}</td><td>{{ printf "%.1f" .GwPing.AvgMs }}</td><td>{{ printf "%.1f" .GwPing.P95Ms }}</td><td>{{ .GwLossPct }}</td><td>{{ printf "%.1f" .GwJitterMs }}</td></tr>
+    <tr><td>WAN Ping</td><td>{{ .TargetHost }}</td><td>{{ printf "%.1f" .WanPing.AvgMs }}</td><td>{{ printf "%.1f" .WanPing.P95Ms }}</td><td>{{ .WanLossPct }}</td><td>{{ printf "%.1f" .WanJitterMs }}</td></tr>
   </table>
 
   <h2>DNS</h2>


### PR DESCRIPTION
## Summary
- extend the ping probe to compute 95th percentile and jitter values from RTT samples
- propagate the richer metrics through reporting templates and health classification logic
- add LAN and WAN performance cards in the web UI to visualize avg/95th/jitter results

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e17f85d124832c90b7084bc6b01429