### PR TITLE
Expose layer-2 discovery results in web UI

### DIFF
--- a/internal/engine/pipeline.go
+++ b/internal/engine/pipeline.go
@@ -131,7 +131,7 @@ func Run(ctx context.Context, params Params) (report.Results, error) {
 		if err := checkCtx(); err != nil {
 			return report.Results{}, err
 		}
-		if hosts, err := probes.L2Scan(scanTimeout, maxHosts, cidrLimit); err == nil {
+		if hosts, err := probes.L2Scan(ctx, scanTimeout, maxHosts, cidrLimit); err == nil {
 			l2Hosts = hosts
 			if len(l2Hosts) == 0 {
 				printer.Println("  No L2 hosts discovered (ARP cache empty).")

--- a/internal/webui/index.html
+++ b/internal/webui/index.html
@@ -84,6 +84,24 @@
                         </div>
                 </section>
 
+                <section class="card" id="devices-card" hidden>
+                        <h2>Discovered Devices (L2)</h2>
+                        <div class="table-responsive">
+                                <table class="data-table" aria-describedby="devices-caption">
+                                        <caption id="devices-caption" class="sr-only">Layer-2 devices found during the scan</caption>
+                                        <thead>
+                                                <tr>
+                                                        <th scope="col">Interface</th>
+                                                        <th scope="col">IP</th>
+                                                        <th scope="col">MAC</th>
+                                                        <th scope="col">Vendor</th>
+                                                </tr>
+                                        </thead>
+                                        <tbody id="devices-body"></tbody>
+                                </table>
+                        </div>
+                </section>
+
                 <section class="card">
                         <h2>Console</h2>
                         <div id="console" class="console" aria-live="polite" aria-atomic="false">

--- a/internal/webui/static/style.css
+++ b/internal/webui/static/style.css
@@ -50,6 +50,54 @@ h1 {
         font-size: 0.95rem;
 }
 
+.table-responsive {
+        width: 100%;
+        overflow-x: auto;
+}
+
+.data-table {
+        width: 100%;
+        border-collapse: collapse;
+        min-width: 480px;
+}
+
+.data-table th,
+.data-table td {
+        text-align: left;
+        padding: 0.6rem 0.75rem;
+        border-bottom: 1px solid #e2e8f0;
+        font-size: 0.95rem;
+}
+
+.data-table th {
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: #64748b;
+        background: rgba(148, 163, 184, 0.15);
+}
+
+.data-table tbody tr:last-child td {
+        border-bottom: none;
+}
+
+.mono {
+        font-family: "SFMono-Regular", "Consolas", "Liberation Mono", monospace;
+        font-size: 0.9rem;
+}
+
+.sr-only {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+}
+
 .metric-grid {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));


### PR DESCRIPTION
## Summary
- make the L2 scan cancellable by context and reuse the embedded OUI database to enrich vendor details
- return vendor-enriched hosts to the engine and render a Discovered Devices (L2) table in the browser UI
- add supporting client-side logic and styling for the new table

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e18231d658832cbc57e00189747180