### PR TITLE
Add vendor pack suggestions and credential modal

### DIFF
--- a/cmd/vne-agent/main.go
+++ b/cmd/vne-agent/main.go
@@ -183,7 +183,7 @@ func main() {
 				ScanMaxHosts:  *scanMaxHostsFlag,
 				ScanCIDRLimit: *scanCIDRLimitFlag,
 				SkipPython:    true,
-				AutoPacks:     false,
+				AutoPacks:     true,
 				SNMPCfg:       nil,
 				Printer:       newProgressPrinter(reporter),
 				Progress:      reporter,

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -36,29 +36,32 @@ type CiscoPackResults struct {
 }
 
 type Results struct {
-	When           time.Time             `json:"when"`
-	UserNote       string                `json:"user_note"`
-	NetInfo        probes.NetInfo        `json:"net_info"`
-	Discovered     []probes.L2Host       `json:"discovered,omitempty"`
-	GwPing         probes.PingResult     `json:"gw_ping"`
-	WanPing        probes.PingResult     `json:"wan_ping"`
-	DNSLocal       probes.DNSResult      `json:"dns_local"`
-	DNSCF          probes.DNSResult      `json:"dns_cf"`
-	Trace          probes.TraceResult    `json:"trace"`
-	MTU            probes.MTUResult      `json:"mtu"`
-	Findings       []Finding             `json:"findings"`
-	FortiRaw       any                   `json:"forti_raw,omitempty"`
-	CiscoIOS       *CiscoPackResults     `json:"cisco_ios,omitempty"`
-	IfaceHealth    *snmp.InterfaceHealth `json:"iface_health,omitempty"`
-	GwLossPct      string                `json:"gw_loss_pct"`
-	WanLossPct     string                `json:"wan_loss_pct"`
-	TargetHost     string                `json:"target_host"`
-	HasGateway     bool                  `json:"has_gateway"`
-	GatewayUsed    string                `json:"gateway_used"`
-	GwJitterMs     float64               `json:"gw_jitter_ms"`
-	WanJitterMs    float64               `json:"wan_jitter_ms"`
-	Classification string                `json:"classification"`
-	Reasons        []string              `json:"reasons"`
+	When              time.Time             `json:"when"`
+	UserNote          string                `json:"user_note"`
+	NetInfo           probes.NetInfo        `json:"net_info"`
+	Discovered        []probes.L2Host       `json:"discovered,omitempty"`
+	GwPing            probes.PingResult     `json:"gw_ping"`
+	WanPing           probes.PingResult     `json:"wan_ping"`
+	DNSLocal          probes.DNSResult      `json:"dns_local"`
+	DNSCF             probes.DNSResult      `json:"dns_cf"`
+	Trace             probes.TraceResult    `json:"trace"`
+	MTU               probes.MTUResult      `json:"mtu"`
+	Findings          []Finding             `json:"findings"`
+	FortiRaw          any                   `json:"forti_raw,omitempty"`
+	CiscoIOS          *CiscoPackResults     `json:"cisco_ios,omitempty"`
+	IfaceHealth       *snmp.InterfaceHealth `json:"iface_health,omitempty"`
+	GwLossPct         string                `json:"gw_loss_pct"`
+	WanLossPct        string                `json:"wan_loss_pct"`
+	TargetHost        string                `json:"target_host"`
+	HasGateway        bool                  `json:"has_gateway"`
+	GatewayUsed       string                `json:"gateway_used"`
+	GwJitterMs        float64               `json:"gw_jitter_ms"`
+	WanJitterMs       float64               `json:"wan_jitter_ms"`
+	Classification    string                `json:"classification"`
+	Reasons           []string              `json:"reasons"`
+	VendorSuggestions []string              `json:"vendor_suggestions,omitempty"`
+	VendorSummaries   []Finding             `json:"vendor_summaries,omitempty"`
+	VendorFindings    []Finding             `json:"vendor_findings,omitempty"`
 }
 
 func RenderHTML(r Results, tmplPath, outPath string) error {

--- a/internal/webui/index.html
+++ b/internal/webui/index.html
@@ -102,6 +102,16 @@
                         </div>
                 </section>
 
+                <section class="card" id="vendor-card" hidden>
+                        <div class="card-header">
+                                <h2>Vendor Checks</h2>
+                                <button type="button" id="vendor-open" class="button-secondary" hidden>Provide credentials</button>
+                        </div>
+                        <p id="vendor-message" class="card-subtitle"></p>
+                        <ul id="vendor-summary" class="list" hidden></ul>
+                        <ul id="vendor-findings" class="list" hidden></ul>
+                </section>
+
                 <section class="card">
                         <h2>Console</h2>
                         <div id="console" class="console" aria-live="polite" aria-atomic="false">
@@ -114,6 +124,58 @@
                         <pre id="results" class="results">(No results yet)</pre>
                 </section>
         </main>
+        <div id="vendor-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="vendor-modal-title" hidden>
+                <div class="modal-backdrop" data-action="close"></div>
+                <div class="modal-content">
+                        <h2 id="vendor-modal-title">Vendor checks</h2>
+                        <p id="vendor-modal-text" class="modal-text">Detected Fortinet/Cisco devices. Provide credentials to run vendor checks.</p>
+                        <form id="vendor-form">
+                                <div id="vendor-forti" class="vendor-block" hidden>
+                                        <h3>Fortinet</h3>
+                                        <label class="field">
+                                                <span>Host/IP</span>
+                                                <input type="text" id="forti-host" autocomplete="off">
+                                        </label>
+                                        <label class="field">
+                                                <span>Username</span>
+                                                <input type="text" id="forti-user" autocomplete="off">
+                                        </label>
+                                        <label class="field">
+                                                <span>Password</span>
+                                                <input type="password" id="forti-pass" autocomplete="off">
+                                        </label>
+                                </div>
+                                <div id="vendor-cisco" class="vendor-block" hidden>
+                                        <h3>Cisco IOS</h3>
+                                        <label class="field">
+                                                <span>Host/IP</span>
+                                                <input type="text" id="cisco-host" autocomplete="off">
+                                        </label>
+                                        <label class="field">
+                                                <span>Username</span>
+                                                <input type="text" id="cisco-user" autocomplete="off">
+                                        </label>
+                                        <label class="field">
+                                                <span>Password</span>
+                                                <input type="password" id="cisco-pass" autocomplete="off">
+                                        </label>
+                                        <label class="field">
+                                                <span>Enable secret (optional)</span>
+                                                <input type="password" id="cisco-secret" autocomplete="off">
+                                        </label>
+                                        <label class="field">
+                                                <span>SSH port (optional)</span>
+                                                <input type="number" id="cisco-port" min="1" max="65535" autocomplete="off">
+                                        </label>
+                                </div>
+                                <p id="vendor-error" class="error" role="alert" hidden></p>
+                                <div class="modal-actions">
+                                        <button type="button" id="vendor-cancel" class="button-secondary">Cancel</button>
+                                        <button type="submit">Run vendor checks</button>
+                                </div>
+                        </form>
+                </div>
+        </div>
         <script src="/static/app.js" defer></script>
 </body>
 </html>

--- a/internal/webui/static/style.css
+++ b/internal/webui/static/style.css
@@ -44,6 +44,13 @@ h1 {
         font-size: 1.4rem;
 }
 
+.card-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+}
+
 .card-subtitle {
         margin: 0.3rem 0 1.1rem;
         color: #52606d;
@@ -154,6 +161,15 @@ button:hover {
         background-color: #1d4ed8;
 }
 
+.button-secondary {
+        background-color: rgba(37, 99, 235, 0.12);
+        color: #2563eb;
+}
+
+.button-secondary:hover {
+        background-color: rgba(37, 99, 235, 0.18);
+}
+
 .status-grid {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
@@ -221,6 +237,74 @@ button:hover {
 .console-empty {
         color: #94a3b8;
         font-style: italic;
+}
+
+.list {
+        margin: 0;
+        padding-left: 1.25rem;
+        color: inherit;
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+}
+
+.list li {
+        line-height: 1.4;
+}
+
+.modal {
+        position: fixed;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        z-index: 1000;
+}
+
+.modal[hidden] {
+        display: none !important;
+}
+
+.modal-backdrop {
+        position: absolute;
+        inset: 0;
+        background: rgba(15, 23, 42, 0.6);
+}
+
+.modal-content {
+        position: relative;
+        background: #fff;
+        color: #1f2933;
+        padding: 2rem;
+        border-radius: 16px;
+        box-shadow: 0 20px 40px rgba(15, 23, 42, 0.2);
+        width: min(480px, 90vw);
+        max-height: 90vh;
+        overflow-y: auto;
+        z-index: 1;
+}
+
+.modal-text {
+        margin-top: 0;
+        color: #52606d;
+}
+
+.modal-actions {
+        display: flex;
+        justify-content: flex-end;
+        gap: 0.75rem;
+        margin-top: 1.5rem;
+}
+
+.vendor-block {
+        margin-top: 1.5rem;
+        padding-top: 1rem;
+        border-top: 1px solid #e2e8f0;
+}
+
+.vendor-block h3 {
+        margin: 0 0 0.75rem;
+        font-size: 1.1rem;
 }
 
 .results {


### PR DESCRIPTION
## Summary
- surface vendor pack suggestions and findings in diagnostics results
- add web UI modal to collect Fortinet and Cisco credentials and trigger vendor checks
- execute vendor packs via the web server and expose findings in the UI

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e184b9faa0832cbb219f780c592bac