### PR TITLE
Add evidence bundle download endpoint and UI button

### DIFF
--- a/internal/webui/index.html
+++ b/internal/webui/index.html
@@ -121,6 +121,7 @@
 
                 <section class="card">
                         <h2>Results</h2>
+                        <button type="button" id="download-bundle" class="button-secondary" hidden>Download bundle</button>
                         <pre id="results" class="results">(No results yet)</pre>
                 </section>
         </main>


### PR DESCRIPTION
## Summary
- add a reusable bundle builder so evidence archives can be streamed
- expose a /api/bundle endpoint and UI control to download the diagnostics bundle

## Testing
- go test ./... *(hangs locally; aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68e187f997c4832cb3d9b1b26d31861f