### PR TITLE
Add run history storage and comparison UI

### DIFF
--- a/internal/history/history.go
+++ b/internal/history/history.go
@@ -1,0 +1,229 @@
+package history
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/cneate93/vne/internal/report"
+)
+
+const (
+	defaultDir     = "runs"
+	defaultMaxRuns = 20
+)
+
+type Store struct {
+	dir string
+	max int
+}
+
+type Entry struct {
+	ID             string    `json:"id"`
+	When           time.Time `json:"when"`
+	Target         string    `json:"target,omitempty"`
+	Classification string    `json:"classification,omitempty"`
+}
+
+func NewStore(dir string, max int) *Store {
+	if strings.TrimSpace(dir) == "" {
+		dir = defaultDir
+	}
+	if max <= 0 {
+		max = defaultMaxRuns
+	}
+	return &Store{dir: dir, max: max}
+}
+
+func (s *Store) Save(res report.Results) (string, error) {
+	if s == nil {
+		return "", errors.New("nil history store")
+	}
+	resCopy := res
+	when := resCopy.When
+	if when.IsZero() {
+		when = time.Now()
+	}
+	resCopy.When = when.UTC()
+
+	if err := os.MkdirAll(s.dir, 0o755); err != nil {
+		return "", err
+	}
+
+	baseID := resCopy.When.Format("20060102-150405")
+	runID := baseID
+	for i := 1; ; i++ {
+		path := s.pathFor(runID)
+		if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+			break
+		}
+		runID = fmt.Sprintf("%s-%02d", baseID, i)
+	}
+
+	data, err := json.MarshalIndent(resCopy, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(s.pathFor(runID), data, 0o644); err != nil {
+		return "", err
+	}
+	if err := s.prune(); err != nil {
+		return runID, err
+	}
+	return runID, nil
+}
+
+func (s *Store) Update(id string, res report.Results) error {
+	if s == nil {
+		return errors.New("nil history store")
+	}
+	cleanID, err := sanitizeID(id)
+	if err != nil {
+		return err
+	}
+	resCopy := res
+	if resCopy.When.IsZero() {
+		resCopy.When = time.Now().UTC()
+	} else {
+		resCopy.When = resCopy.When.UTC()
+	}
+	if err := os.MkdirAll(s.dir, 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(resCopy, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(s.pathFor(cleanID), data, 0o644)
+}
+
+func (s *Store) List() ([]Entry, error) {
+	if s == nil {
+		return nil, errors.New("nil history store")
+	}
+	names, err := s.sortedRunFiles()
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if len(names) == 0 {
+		return nil, nil
+	}
+	entries := make([]Entry, 0, len(names))
+	for idx, name := range names {
+		if s.max > 0 && idx >= s.max {
+			break
+		}
+		id := strings.TrimSuffix(name, ".json")
+		res, err := s.readMeta(id)
+		if err != nil {
+			continue
+		}
+		entries = append(entries, res)
+	}
+	return entries, nil
+}
+
+func (s *Store) Load(id string) (*report.Results, error) {
+	if s == nil {
+		return nil, errors.New("nil history store")
+	}
+	cleanID, err := sanitizeID(id)
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(s.pathFor(cleanID))
+	if err != nil {
+		return nil, err
+	}
+	var res report.Results
+	if err := json.Unmarshal(data, &res); err != nil {
+		return nil, err
+	}
+	return &res, nil
+}
+
+func (s *Store) prune() error {
+	names, err := s.sortedRunFiles()
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	if s.max <= 0 || len(names) <= s.max {
+		return nil
+	}
+	for _, name := range names[s.max:] {
+		_ = os.Remove(filepath.Join(s.dir, name))
+	}
+	return nil
+}
+
+func (s *Store) sortedRunFiles() ([]string, error) {
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		return nil, err
+	}
+	var names []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if strings.HasSuffix(name, ".json") {
+			names = append(names, name)
+		}
+	}
+	sort.Slice(names, func(i, j int) bool {
+		return names[i] > names[j]
+	})
+	return names, nil
+}
+
+func (s *Store) readMeta(id string) (Entry, error) {
+	cleanID, err := sanitizeID(id)
+	if err != nil {
+		return Entry{}, err
+	}
+	data, err := os.ReadFile(s.pathFor(cleanID))
+	if err != nil {
+		return Entry{}, err
+	}
+	var meta struct {
+		When           time.Time `json:"when"`
+		Target         string    `json:"target_host"`
+		Classification string    `json:"classification"`
+	}
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return Entry{}, err
+	}
+	return Entry{
+		ID:             cleanID,
+		When:           meta.When,
+		Target:         strings.TrimSpace(meta.Target),
+		Classification: strings.TrimSpace(meta.Classification),
+	}, nil
+}
+
+func (s *Store) pathFor(id string) string {
+	return filepath.Join(s.dir, fmt.Sprintf("%s.json", id))
+}
+
+func sanitizeID(id string) (string, error) {
+	trimmed := strings.TrimSpace(id)
+	if trimmed == "" {
+		return "", os.ErrNotExist
+	}
+	if strings.Contains(trimmed, "..") || strings.ContainsAny(trimmed, "/\\") {
+		return "", os.ErrNotExist
+	}
+	return trimmed, nil
+}

--- a/internal/webui/index.html
+++ b/internal/webui/index.html
@@ -12,118 +12,178 @@
                         <p class="tagline">Run diagnostics from your browser.</p>
                 </header>
 
-                <section class="card">
-                        <h2>Start a run</h2>
-                        <form id="start-form">
-                                <label class="field">
-                                        <span>Internet target</span>
-                                        <input type="text" name="target" id="target" value="1.1.1.1" autocomplete="off">
-                                </label>
-                                <label class="checkbox">
-                                        <input type="checkbox" name="scan" id="scan">
-                                        <span>Include local layer-2 discovery (experimental)</span>
-                                </label>
-                                <button type="submit">Start diagnostics</button>
-                        </form>
-                        <p id="start-error" class="error" role="alert" hidden></p>
-                </section>
+                <div class="content-grid">
+                        <aside class="card history-card" id="history-card">
+                                <h2>Recent runs</h2>
+                                <p id="history-empty" class="history-empty">(No saved runs yet.)</p>
+                                <ul id="history-list" class="history-list" aria-label="Recent runs"></ul>
+                                <div class="history-compare" id="history-compare" hidden>
+                                        <span class="label">Comparing with</span>
+                                        <p id="compare-label" class="history-compare-label">—</p>
+                                        <button type="button" id="clear-compare" class="button-secondary button-small">Clear</button>
+                                </div>
+                        </aside>
 
-                <section class="card">
-                        <h2>Status</h2>
-                        <div class="status-grid">
-                                <div>
-                                        <span class="label">Phase</span>
-                                        <span id="status-phase">Idle</span>
-                                </div>
-                                <div>
-                                        <span class="label">Progress</span>
-                                        <span id="status-percent">0%</span>
-                                </div>
-                        </div>
-                        <div class="progress" aria-hidden="true">
-                                <div class="progress-bar" id="progress-bar"></div>
-                        </div>
-                        <p id="status-message" class="status-message">Ready</p>
-                </section>
+                        <div class="content-main">
+                                <section class="card">
+                                        <h2>Start a run</h2>
+                                        <form id="start-form">
+                                                <label class="field">
+                                                        <span>Internet target</span>
+                                                        <input type="text" name="target" id="target" value="1.1.1.1" autocomplete="off">
+                                                </label>
+                                                <label class="checkbox">
+                                                        <input type="checkbox" name="scan" id="scan">
+                                                        <span>Include local layer-2 discovery (experimental)</span>
+                                                </label>
+                                                <button type="submit">Start diagnostics</button>
+                                        </form>
+                                        <p id="start-error" class="error" role="alert" hidden></p>
+                                </section>
 
-                <section class="card" id="lan-card" hidden>
-                        <h2>LAN Performance</h2>
-                        <p class="card-subtitle">Default gateway: <span id="lan-dest">(detecting…)</span></p>
-                        <div class="metric-grid">
-                                <div class="metric">
-                                        <span class="label">Avg RTT</span>
-                                        <span id="lan-avg" class="metric-value">—</span>
-                                </div>
-                                <div class="metric">
-                                        <span class="label">95th Percentile</span>
-                                        <span id="lan-p95" class="metric-value">—</span>
-                                </div>
-                                <div class="metric">
-                                        <span class="label">Jitter</span>
-                                        <span id="lan-jitter" class="metric-value">—</span>
-                                </div>
-                        </div>
-                </section>
+                                <section class="card">
+                                        <h2>Status</h2>
+                                        <div class="status-grid">
+                                                <div>
+                                                        <span class="label">Phase</span>
+                                                        <span id="status-phase">Idle</span>
+                                                </div>
+                                                <div>
+                                                        <span class="label">Progress</span>
+                                                        <span id="status-percent">0%</span>
+                                                </div>
+                                        </div>
+                                        <div class="progress" aria-hidden="true">
+                                                <div class="progress-bar" id="progress-bar"></div>
+                                        </div>
+                                        <p id="status-message" class="status-message">Ready</p>
+                                </section>
 
-                <section class="card" id="wan-card" hidden>
-                        <h2>WAN Performance</h2>
-                        <p class="card-subtitle">Target host: <span id="wan-dest">(detecting…)</span></p>
-                        <div class="metric-grid">
-                                <div class="metric">
-                                        <span class="label">Avg RTT</span>
-                                        <span id="wan-avg" class="metric-value">—</span>
-                                </div>
-                                <div class="metric">
-                                        <span class="label">95th Percentile</span>
-                                        <span id="wan-p95" class="metric-value">—</span>
-                                </div>
-                                <div class="metric">
-                                        <span class="label">Jitter</span>
-                                        <span id="wan-jitter" class="metric-value">—</span>
-                                </div>
-                        </div>
-                </section>
+                                <section class="card" id="lan-card" hidden>
+                                        <h2>LAN Performance</h2>
+                                        <p class="card-subtitle">Default gateway: <span id="lan-dest">(detecting…)</span></p>
+                                        <div class="metric-grid">
+                                                <div class="metric">
+                                                        <span class="label">Avg RTT</span>
+                                                        <span id="lan-avg" class="metric-value">—</span>
+                                                </div>
+                                                <div class="metric">
+                                                        <span class="label">95th Percentile</span>
+                                                        <span id="lan-p95" class="metric-value">—</span>
+                                                </div>
+                                                <div class="metric">
+                                                        <span class="label">Jitter</span>
+                                                        <span id="lan-jitter" class="metric-value">—</span>
+                                                </div>
+                                        </div>
+                                </section>
 
-                <section class="card" id="devices-card" hidden>
-                        <h2>Discovered Devices (L2)</h2>
-                        <div class="table-responsive">
-                                <table class="data-table" aria-describedby="devices-caption">
-                                        <caption id="devices-caption" class="sr-only">Layer-2 devices found during the scan</caption>
-                                        <thead>
-                                                <tr>
-                                                        <th scope="col">Interface</th>
-                                                        <th scope="col">IP</th>
-                                                        <th scope="col">MAC</th>
-                                                        <th scope="col">Vendor</th>
-                                                </tr>
-                                        </thead>
-                                        <tbody id="devices-body"></tbody>
-                                </table>
-                        </div>
-                </section>
+                                <section class="card" id="wan-card" hidden>
+                                        <h2>WAN Performance</h2>
+                                        <p class="card-subtitle">Target host: <span id="wan-dest">(detecting…)</span></p>
+                                        <div class="metric-grid">
+                                                <div class="metric">
+                                                        <span class="label">Avg RTT</span>
+                                                        <span id="wan-avg" class="metric-value">—</span>
+                                                </div>
+                                                <div class="metric">
+                                                        <span class="label">95th Percentile</span>
+                                                        <span id="wan-p95" class="metric-value">—</span>
+                                                </div>
+                                                <div class="metric">
+                                                        <span class="label">Jitter</span>
+                                                        <span id="wan-jitter" class="metric-value">—</span>
+                                                </div>
+                                        </div>
+                                </section>
 
-                <section class="card" id="vendor-card" hidden>
-                        <div class="card-header">
-                                <h2>Vendor Checks</h2>
-                                <button type="button" id="vendor-open" class="button-secondary" hidden>Provide credentials</button>
-                        </div>
-                        <p id="vendor-message" class="card-subtitle"></p>
-                        <ul id="vendor-summary" class="list" hidden></ul>
-                        <ul id="vendor-findings" class="list" hidden></ul>
-                </section>
+                                <section class="card" id="compare-card" hidden>
+                                        <h2>Comparison</h2>
+                                        <p id="compare-summary" class="card-subtitle"></p>
+                                        <div class="compare-grid">
+                                                <div class="compare-group">
+                                                        <h3>Gateway</h3>
+                                                        <dl class="compare-metrics">
+                                                                <div>
+                                                                        <dt>Loss</dt>
+                                                                        <dd id="compare-gw-loss">—</dd>
+                                                                </div>
+                                                                <div>
+                                                                        <dt>Avg RTT</dt>
+                                                                        <dd id="compare-gw-rtt">—</dd>
+                                                                </div>
+                                                                <div>
+                                                                        <dt>Jitter</dt>
+                                                                        <dd id="compare-gw-jitter">—</dd>
+                                                                </div>
+                                                        </dl>
+                                                </div>
+                                                <div class="compare-group">
+                                                        <h3>WAN</h3>
+                                                        <dl class="compare-metrics">
+                                                                <div>
+                                                                        <dt>Loss</dt>
+                                                                        <dd id="compare-wan-loss">—</dd>
+                                                                </div>
+                                                                <div>
+                                                                        <dt>Avg RTT</dt>
+                                                                        <dd id="compare-wan-rtt">—</dd>
+                                                                </div>
+                                                                <div>
+                                                                        <dt>Jitter</dt>
+                                                                        <dd id="compare-wan-jitter">—</dd>
+                                                                </div>
+                                                        </dl>
+                                                </div>
+                                                <div class="compare-group">
+                                                        <h3>MTU</h3>
+                                                        <p id="compare-mtu">—</p>
+                                                </div>
+                                        </div>
+                                </section>
 
-                <section class="card">
-                        <h2>Console</h2>
-                        <div id="console" class="console" aria-live="polite" aria-atomic="false">
-                                <div class="console-empty">No activity yet.</div>
-                        </div>
-                </section>
+                                <section class="card" id="devices-card" hidden>
+                                        <h2>Discovered Devices (L2)</h2>
+                                        <div class="table-responsive">
+                                                <table class="data-table" aria-describedby="devices-caption">
+                                                        <caption id="devices-caption" class="sr-only">Layer-2 devices found during the scan</caption>
+                                                        <thead>
+                                                                <tr>
+                                                                        <th scope="col">Interface</th>
+                                                                        <th scope="col">IP</th>
+                                                                        <th scope="col">MAC</th>
+                                                                        <th scope="col">Vendor</th>
+                                                                </tr>
+                                                        </thead>
+                                                        <tbody id="devices-body"></tbody>
+                                                </table>
+                                        </div>
+                                </section>
 
-                <section class="card">
-                        <h2>Results</h2>
-                        <button type="button" id="download-bundle" class="button-secondary" hidden>Download bundle</button>
-                        <pre id="results" class="results">(No results yet)</pre>
-                </section>
+                                <section class="card" id="vendor-card" hidden>
+                                        <div class="card-header">
+                                                <h2>Vendor Checks</h2>
+                                                <button type="button" id="vendor-open" class="button-secondary" hidden>Provide credentials</button>
+                                        </div>
+                                        <p id="vendor-message" class="card-subtitle"></p>
+                                        <ul id="vendor-summary" class="list" hidden></ul>
+                                        <ul id="vendor-findings" class="list" hidden></ul>
+                                </section>
+
+                                <section class="card">
+                                        <h2>Console</h2>
+                                        <div id="console" class="console" aria-live="polite" aria-atomic="false">
+                                                <div class="console-empty">No activity yet.</div>
+                                        </div>
+                                </section>
+
+                                <section class="card">
+                                        <h2>Results</h2>
+                                        <button type="button" id="download-bundle" class="button-secondary" hidden>Download bundle</button>
+                                        <pre id="results" class="results">(No results yet)</pre>
+                                </section>
+                        </div>
+                </div>
         </main>
         <div id="vendor-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="vendor-modal-title" hidden>
                 <div class="modal-backdrop" data-action="close"></div>

--- a/internal/webui/static/style.css
+++ b/internal/webui/static/style.css
@@ -11,7 +11,7 @@ body {
 }
 
 .container {
-        max-width: 900px;
+        max-width: 1100px;
         margin: 0 auto;
         padding: 2rem 1.5rem 3rem;
 }
@@ -328,4 +328,195 @@ button:hover {
         .container {
                 padding: 1.5rem 1rem 2rem;
         }
+}
+.content-grid {
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+}
+
+.content-main {
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+}
+
+@media (min-width: 960px) {
+        .content-grid {
+                flex-direction: row;
+                align-items: flex-start;
+        }
+        .history-card {
+                flex: 0 0 260px;
+                position: sticky;
+                top: 1.5rem;
+                align-self: flex-start;
+        }
+        .content-main {
+                flex: 1;
+        }
+}
+
+.history-card h2 {
+        margin-top: 0;
+}
+
+.history-empty {
+        margin: 0.5rem 0 0;
+        font-size: 0.9rem;
+        color: #64748b;
+}
+
+.history-list {
+        list-style: none;
+        margin: 0.75rem 0 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 0.6rem;
+}
+
+.history-item {
+        display: flex;
+        align-items: center;
+        gap: 0.6rem;
+        padding: 0.7rem 0.75rem;
+        border-radius: 12px;
+        background: rgba(148, 163, 184, 0.12);
+        border: 1px solid transparent;
+        transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.history-item.is-active {
+        background: rgba(37, 99, 235, 0.15);
+        border-color: rgba(37, 99, 235, 0.45);
+}
+
+.history-item.is-compare {
+        box-shadow: inset 0 0 0 1px rgba(220, 38, 38, 0.45);
+}
+
+.history-select {
+        flex: 1;
+        background: none;
+        border: none;
+        color: inherit;
+        text-align: left;
+        padding: 0;
+        font: inherit;
+        cursor: pointer;
+}
+
+.history-select:focus-visible {
+        outline: 2px solid #2563eb;
+        outline-offset: 2px;
+}
+
+.history-run-time {
+        display: block;
+        font-weight: 600;
+        font-size: 0.95rem;
+}
+
+.history-run-target {
+        display: block;
+        font-size: 0.85rem;
+        color: #52606d;
+}
+
+.history-run-classification {
+        display: inline-block;
+        margin-top: 0.3rem;
+        font-size: 0.75rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: #475569;
+}
+
+.history-compare-btn {
+        background: rgba(37, 99, 235, 0.12);
+        border: none;
+        color: #2563eb;
+        padding: 0.35rem 0.6rem;
+        border-radius: 8px;
+        font-size: 0.8rem;
+        cursor: pointer;
+        transition: background-color 0.2s ease;
+}
+
+.history-compare-btn:hover,
+.history-compare-btn:focus-visible {
+        background: rgba(37, 99, 235, 0.2);
+        outline: none;
+}
+
+.history-item.is-compare .history-compare-btn {
+        background: rgba(220, 38, 38, 0.18);
+        color: #b91c1c;
+}
+
+.history-compare {
+        margin-top: 1.5rem;
+        padding-top: 1rem;
+        border-top: 1px solid rgba(148, 163, 184, 0.4);
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+}
+
+.history-compare-label {
+        margin: 0;
+        font-weight: 600;
+}
+
+.button-small {
+        padding: 0.45rem 0.85rem;
+        font-size: 0.85rem;
+        border-radius: 999px;
+}
+
+.compare-grid {
+        display: grid;
+        gap: 1rem;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.compare-group h3 {
+        margin: 0 0 0.5rem;
+        font-size: 1.05rem;
+}
+
+.compare-metrics {
+        margin: 0;
+        padding: 0;
+}
+
+.compare-metrics div {
+        display: flex;
+        justify-content: space-between;
+        gap: 0.75rem;
+        padding: 0.35rem 0;
+        border-bottom: 1px solid rgba(226, 232, 240, 0.6);
+        font-size: 0.95rem;
+}
+
+.compare-metrics div:last-child {
+        border-bottom: none;
+}
+
+.compare-metrics dt {
+        margin: 0;
+        font-weight: 500;
+}
+
+.compare-metrics dd {
+        margin: 0;
+        text-align: right;
+        font-feature-settings: "tnum";
+}
+
+.compare-group p {
+        margin: 0;
+        font-size: 0.95rem;
+        font-weight: 500;
 }


### PR DESCRIPTION
## Summary
- persist completed run results to timestamped files and expose history endpoints
- add recent run selection with comparison deltas in the web UI
- refresh layout and styles to surface history sidebar and compare card

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e18a324c40832c984244cf57d250ed